### PR TITLE
feat: add no-swallowed-errors rule

### DIFF
--- a/.changeset/no-swallowed-errors-rule.md
+++ b/.changeset/no-swallowed-errors-rule.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-llm-core": minor
+---
+
+Add `no-swallowed-errors` rule — flags catch blocks that only log to console without rethrowing, returning, or delegating to an error handler

--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ export default [
 | [no-llm-artifacts](docs/rules/no-llm-artifacts.md)                                 | Disallow common LLM placeholder comments and incomplete code markers that indicate skipped implementation    | 🌐 🧹 ✅ |     |
 | [no-magic-numbers](docs/rules/no-magic-numbers.md)                                 | Disallow magic numbers and enforce named constants for clarity                                               | 🌐 🏆 ✅ |     |
 | [no-redundant-logic](docs/rules/no-redundant-logic.md)                             | Disallow redundant boolean logic and unnecessary control flow patterns                                       | 🌐 ✅ 🎨 | 💡  |
+| [no-swallowed-errors](docs/rules/no-swallowed-errors.md)                           | Disallow catch blocks that only log to console and swallow the error                                         | 🌐 🏆 ✅ |     |
 | [no-type-assertion-any](docs/rules/no-type-assertion-any.md)                       | Disallow type assertions to `any` that bypass TypeScript's type safety                                       | 🌐 ✅ ⌨️ |     |
 | [prefer-early-return](docs/rules/prefer-early-return.md)                           | Enforce guard clauses (early returns) instead of wrapping function bodies in a single if statement           | 🌐 ✅ 🎨 |     |
 | [prefer-unknown-in-catch](docs/rules/prefer-unknown-in-catch.md)                   | Disallow `any` type annotation on catch clause parameters; prefer `unknown`                                  | 🌐 ✅ ⌨️ |     |

--- a/docs/rules/no-swallowed-errors.md
+++ b/docs/rules/no-swallowed-errors.md
@@ -1,0 +1,90 @@
+# llm-core/no-swallowed-errors
+
+📝 Disallow catch blocks that only log to console and swallow the error.
+
+💼 This rule is enabled in the following configs: 🌐 `all`, 🏆 `best-practices`, ✅ `recommended`.
+
+<!-- end auto-generated rule header -->
+
+Disallow `catch` blocks that only call `console.log`, `console.warn`, `console.error`, or `console.debug` without rethrowing, returning, or delegating the failure to a real error handler.
+
+## Rule Details
+
+LLMs often generate placeholder error handling like `catch (error) { console.error(error); }`. That looks intentional, but it still swallows the failure: callers do not see an error, control flow continues, and production systems quietly drift into bad state.
+
+This rule focuses on the narrow, high-signal case where a non-empty `catch` block contains **only console logging calls**. It deliberately does **not** overlap with `no-empty-catch` — truly empty or comment-only blocks belong to that rule.
+
+## Examples
+
+### Incorrect
+
+```ts
+try {
+  await processOrder(order);
+} catch (error) {
+  console.error(error);
+}
+
+try {
+  await loadConfig();
+} catch (error) {
+  console.warn("Config failed", error);
+  console.debug(error);
+}
+```
+
+### Correct
+
+```ts
+try {
+  await processOrder(order);
+} catch (error) {
+  throw new Error("Failed to process order", { cause: error });
+}
+
+try {
+  return await loadConfig();
+} catch (error) {
+  logger.error("Config load failed", { error });
+  return null;
+}
+
+try {
+  await publishEvent(event);
+} catch (error) {
+  Sentry.captureException(error);
+}
+
+try {
+  await performWork();
+} catch (error) {
+  console.error(error);
+  throw error;
+}
+```
+
+## What This Rule Flags
+
+| Catch body contents                             | Flagged? |
+| ----------------------------------------------- | -------- |
+| `console.error(error)`                          | ✅ Yes   |
+| `console.log(error); console.warn("failed", e)` | ✅ Yes   |
+| `console.error(error); throw error;`            | ❌ No    |
+| `console.error(error); handleError(error);`     | ❌ No    |
+| `handleError(error)`                            | ❌ No    |
+| empty `catch {}`                                | ❌ No    |
+
+## Why Console-Only Handling Is Risky
+
+- Logging alone does not change control flow.
+- Callers cannot recover because they never learn the operation failed.
+- Background tasks can keep running with partial or invalid state.
+- The code looks "handled" in review even though the failure was dropped.
+
+## Error Messages
+
+The teaching message explains:
+
+1. **What's wrong** — the catch block only logs and swallows the error
+2. **Why** — execution continues as if nothing failed
+3. **How to fix** — rethrow, return an explicit fallback, or delegate to a real handler such as a logger or error tracker

--- a/evals/README.md
+++ b/evals/README.md
@@ -97,6 +97,7 @@ git show origin/eval-results:eval-2026-04-09.json  # specific result
 | `event-system.ts`       | naming-conventions, no-exported-function-expressions, explicit-export-types, no-async-array-callbacks, consistent-catch-param-name, throw-error-objects, prefer-early-return |
 | `file-structure.ts`     | max-file-length, max-function-length, max-params, no-magic-numbers, structured-logging, no-exported-function-expressions, no-empty-catch, throw-error-objects                |
 | `integration-module.ts` | no-commented-out-code, no-llm-artifacts, no-inline-disable, explicit-export-types, no-async-array-callbacks, max-params, structured-logging                                  |
+| `swallowed-errors.ts`   | no-swallowed-errors, prefer-unknown-in-catch, structured-logging, throw-error-objects, no-magic-numbers                                                                      |
 
 ## Output
 

--- a/evals/fixtures/swallowed-errors.ts
+++ b/evals/fixtures/swallowed-errors.ts
@@ -1,0 +1,109 @@
+// Expected violations: ~10
+// Rules triggered:
+//   no-swallowed-errors (3): decodeWebhookPayload, persistAuditEvent, publishWebhook — console-only catch blocks (all console.*)
+//   prefer-unknown-in-catch (2): decodeWebhookPayload, runWebhookJob — catch (error: any)
+//   structured-logging (1): runWebhookJob — template literal in logger.error call
+//   throw-error-objects (2): loadWebhookConfig (string), createWebhookError (object)
+//   no-magic-numbers (2): loadWebhookConfig (3), runWebhookJob (500)
+//
+// Key challenge: the fixture mixes swallowed errors with nearby logging and rethrow
+// patterns that should stay valid. The model has to preserve explicit outcomes while
+// replacing console-only catches with real error handling.
+
+interface WebhookPayload {
+  id: string;
+  eventType: string;
+  attempts: number;
+  body: Record<string, unknown>;
+}
+
+interface WebhookConfig {
+  endpoint: string;
+  maxAttempts: number;
+}
+
+const logger = {
+  info: (message: string, meta?: Record<string, unknown>) =>
+    console.log(message, meta),
+  warn: (message: string, meta?: Record<string, unknown>) =>
+    console.warn(message, meta),
+  error: (message: string, meta?: Record<string, unknown>) =>
+    console.error(message, meta),
+};
+
+function loadWebhookConfig(name: string): WebhookConfig {
+  if (name === "legacy") {
+    throw "Legacy webhook config missing";
+  }
+
+  return {
+    endpoint: `/internal/webhooks/${name}`,
+    maxAttempts: 3,
+  };
+}
+
+function decodeWebhookPayload(raw: string): WebhookPayload | null {
+  try {
+    return JSON.parse(raw) as WebhookPayload;
+  } catch (error: any) {
+    console.error(`Webhook decode failed for payload ${raw.length}`, error);
+  }
+
+  return null;
+}
+
+async function persistAuditEvent(payload: WebhookPayload): Promise<void> {
+  try {
+    await fetch("/internal/audit-events", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+  } catch (error) {
+    console.warn(`Audit write failed for ${payload.id}`, error);
+  }
+}
+
+function createWebhookError(payload: WebhookPayload): never {
+  throw { payloadId: payload.id, message: "Webhook publish failed" };
+}
+
+async function publishWebhook(payload: WebhookPayload): Promise<void> {
+  try {
+    await fetch(`/internal/webhooks/${payload.eventType}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload.body),
+    });
+  } catch (error) {
+    console.log(error);
+    console.error(payload.id);
+  }
+}
+
+export async function runWebhookJob(rawPayload: string): Promise<void> {
+  const config = loadWebhookConfig("orders");
+  const payload = decodeWebhookPayload(rawPayload);
+
+  if (!payload) {
+    return;
+  }
+
+  try {
+    if (payload.attempts > config.maxAttempts) {
+      createWebhookError(payload);
+    }
+
+    await persistAuditEvent(payload);
+    await publishWebhook(payload);
+    logger.info("Webhook processed", { payloadId: payload.id });
+  } catch (error: any) {
+    if (error.statusCode === 500) {
+      logger.error(`Webhook failed permanently for ${payload.id}`);
+      return;
+    }
+
+    logger.error("Webhook processing aborted", { payloadId: payload.id });
+    throw new Error("Webhook job failed", { cause: error });
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,9 +32,10 @@ const typescriptRules: TSESLint.FlatConfig.Rules = {
 const bestPracticesRules: TSESLint.FlatConfig.Rules = {
   "llm-core/no-async-array-callbacks": "error",
   "llm-core/no-empty-catch": "error",
-  "llm-core/throw-error-objects": "error",
-  "llm-core/structured-logging": "error",
   "llm-core/no-magic-numbers": "error",
+  "llm-core/no-swallowed-errors": "error",
+  "llm-core/structured-logging": "error",
+  "llm-core/throw-error-objects": "error",
 };
 
 const styleRules: TSESLint.FlatConfig.Rules = {

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -15,6 +15,7 @@ export { default as "no-inline-disable" } from "./no-inline-disable";
 export { default as "no-llm-artifacts" } from "./no-llm-artifacts";
 export { default as "no-magic-numbers" } from "./no-magic-numbers";
 export { default as "no-redundant-logic" } from "./no-redundant-logic";
+export { default as "no-swallowed-errors" } from "./no-swallowed-errors";
 export { default as "no-type-assertion-any" } from "./no-type-assertion-any";
 export { default as "prefer-early-return" } from "./prefer-early-return";
 export { default as "prefer-unknown-in-catch" } from "./prefer-unknown-in-catch";

--- a/src/rules/no-swallowed-errors.ts
+++ b/src/rules/no-swallowed-errors.ts
@@ -1,0 +1,88 @@
+import { TSESTree } from "@typescript-eslint/utils";
+import { createRule } from "../utils/create-rule";
+
+type MessageIds = "noSwallowedErrors";
+
+export default createRule<[], MessageIds>({
+  name: "no-swallowed-errors",
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow catch blocks that only log to console and swallow the error",
+    },
+    messages: {
+      noSwallowedErrors: [
+        "Catch block only logs the error — it is silently swallowed.",
+        "",
+        "Why: Logging an error without rethrowing, returning, or delegating to an error handler",
+        "means the program continues as if nothing failed. Callers cannot detect or recover from",
+        "the failure.",
+        "",
+        "How to fix:",
+        "  Choose one explicit outcome:",
+        "  Before: catch (error) { console.log(error); }",
+        "  After:  catch (error) { throw new Error('Failed to process', { cause: error }); }",
+        "  After:  catch (error) { logger.error('Process failed', { error }); return { success: false, error }; }",
+        "  After:  catch (error) { Sentry.captureException(error); }",
+      ].join("\n"),
+    },
+    schema: [],
+  },
+  defaultOptions: [],
+  create(context) {
+    function isConsoleOnlyCatchStatement(
+      statement: TSESTree.Statement,
+    ): boolean {
+      if (statement.type !== "ExpressionStatement") {
+        return false;
+      }
+
+      const expression = statement.expression;
+      if (expression.type !== "CallExpression") {
+        return false;
+      }
+
+      const callee = expression.callee;
+      if (callee.type !== "MemberExpression" || callee.computed) {
+        return false;
+      }
+
+      if (
+        callee.object.type !== "Identifier" ||
+        callee.object.name !== "console"
+      ) {
+        return false;
+      }
+
+      return (
+        callee.property.type === "Identifier" &&
+        ["log", "warn", "error", "debug"].includes(callee.property.name)
+      );
+    }
+
+    return {
+      CatchClause(node: TSESTree.CatchClause) {
+        const statements = node.body.body.filter(
+          (
+            statement,
+          ): statement is Exclude<
+            TSESTree.Statement,
+            TSESTree.EmptyStatement
+          > => statement.type !== "EmptyStatement",
+        );
+
+        if (statements.length === 0) {
+          return;
+        }
+
+        if (statements.every(isConsoleOnlyCatchStatement)) {
+          context.report({
+            node: node.body,
+            messageId: "noSwallowedErrors",
+          });
+        }
+      },
+    };
+  },
+});

--- a/tests/rules/no-swallowed-errors.test.ts
+++ b/tests/rules/no-swallowed-errors.test.ts
@@ -1,0 +1,47 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import rule from "../../src/rules/no-swallowed-errors";
+import { describe, it, afterAll } from "vitest";
+
+RuleTester.afterAll = afterAll;
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("no-swallowed-errors", rule, {
+  valid: [
+    `try { doWork(); } catch (e) {}`,
+    `try { doWork(); } catch (e) { ; }`,
+    `try { doWork(); } catch (e) { throw e; }`,
+    `try { doWork(); } catch (e) { throw new Error('fail', { cause: e }); }`,
+    `function safe() { try { return doWork(); } catch (e) { return null; } }`,
+    `try { doWork(); } catch (e) { logger.error('fail', e); }`,
+    `try { doWork(); } catch (e) { logger.error(e); throw e; }`,
+    `try { doWork(); } catch (e) { console.error(e); throw e; }`,
+    `try { doWork(); } catch (e) { Sentry.captureException(e); }`,
+    `try { doWork(); } catch (e) { handleError(e); }`,
+    `try { doWork(); } catch (e) { console.error(e); handleError(e); }`,
+  ],
+  invalid: [
+    {
+      code: `try { doWork(); } catch (e) { console.log(e); }`,
+      errors: [{ messageId: "noSwallowedErrors" as const }],
+    },
+    {
+      code: `try { doWork(); } catch (e) { console.error(e); }`,
+      errors: [{ messageId: "noSwallowedErrors" as const }],
+    },
+    {
+      code: `try { doWork(); } catch (e) { console.warn('Failed', e); }`,
+      errors: [{ messageId: "noSwallowedErrors" as const }],
+    },
+    {
+      code: `try { doWork(); } catch (e) { console.log(e); console.error(e); }`,
+      errors: [{ messageId: "noSwallowedErrors" as const }],
+    },
+    {
+      code: `try { doWork(); } catch (e) { console.debug(e); }`,
+      errors: [{ messageId: "noSwallowedErrors" as const }],
+    },
+  ],
+});


### PR DESCRIPTION
## What does this PR do?

Adds `no-swallowed-errors` rule that flags catch blocks containing only `console.log/warn/error/debug` calls — errors that are logged but never rethrown, returned, or delegated to a proper handler. Complements the existing `no-empty-catch` rule. Includes eval fixture for measuring LLM fix iterations.

Closes #64

## Checklist

- [x] `npm run build` passes
- [x] `npm run test` passes (new tests added if applicable)
- [x] `npm run lint` passes
- [x] `npm run update:eslint-docs` ran (if rules were added or changed)
- [x] Docs added/updated (if adding a new rule: `docs/rules/<rule-name>.md`)
- [x] Rule exported in `src/rules/index.ts` (if adding a new rule)
- [x] Rule added to `recommendedRules` in `src/index.ts` (if applicable)

## Agent Disclosure (complete if this PR was authored by an AI agent)

**Agent:** Sisyphus (OpenCode + Sisyphus-Junior)

**Instruction files loaded:**

- [ ] `.github/copilot-instructions.md`
- [ ] `.github/instructions/rule-implementation.md`
- [ ] `.github/instructions/rule-tests.md`
- [ ] `.github/instructions/rule-docs.md`
- [ ] `.github/instructions/plugin-config.md`
- [x] `AGENTS.md`
- [x] `.agents/directives/TYPE_DRIVEN_DEVELOPMENT.md`
- [x] `.agents/directives/TEST_DRIVEN_DEVELOPMENT.md`
- [x] `.agents/directives/SESSION_DECISIONS.md`
- [ ] If `SESSION_DECISIONS.md` was loaded **and** this PR set a durable repo/process or cross-cutting decision whose reasoning is not obvious from the diff, a `docs/decisions/YYYY-MM-DD-<topic>.md` entry is included in this PR

**Instruction files NOT loaded (explain if unexpected):**

The `.github/instructions/` scoped files were not loaded — these apply to GitHub-native agents (Copilot). Sisyphus operates through OpenCode and loaded the equivalent top-level directives (`AGENTS.md`, `.agents/directives/*`).

## Changes

| File | Change |
|------|--------|
| `src/rules/no-swallowed-errors.ts` | Rule implementation |
| `tests/rules/no-swallowed-errors.test.ts` | 12 valid + 5 invalid test cases |
| `src/rules/index.ts` | Export added (alphabetical) |
| `src/index.ts` | Added to `bestPracticesRules` / `recommended` |
| `docs/rules/no-swallowed-errors.md` | Rule documentation |
| `evals/fixtures/swallowed-errors.ts` | Eval fixture with 3 swallowed-error violations + complementary rule violations |
| `evals/README.md` | Fixture table updated |
| `README.md` | Auto-generated rule table updated |
| `.changeset/no-swallowed-errors-rule.md` | Changeset for minor version bump |

## Rule Design

**What it flags:** Non-empty catch blocks where ALL effective statements are `console.*` calls.

**What it allows:**
- Rethrows (`throw e` / `throw new Error('msg', { cause: e })`)
- Returns (`return null`)
- Non-console function calls (`logger.error()`, `Sentry.captureException()`, `handleError()`)
- Console + rethrow / console + handler (mixed statements = not swallowed)

**No overlap with `no-empty-catch`:** Empty and comment-only catch blocks are skipped — those belong to `no-empty-catch`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new ESLint rule that flags catch blocks that only log to console without rethrowing, returning, or forwarding the error; enabled in best-practices/recommended configs.

* **Documentation**
  * Added full rule docs with examples, guidance, flagged/not-flagged table, and clear error messages.

* **Tests**
  * Added a test suite covering valid and invalid catch patterns.

* **Evals / Fixtures**
  * Added an eval fixture and updated fixtures matrix to exercise the rule.

* **Chores**
  * Added a changeset entry for a minor release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->