### PR TITLE
test: fill gaps in max-complexity operator coverage

### DIFF
--- a/tests/rules/max-complexity.test.ts
+++ b/tests/rules/max-complexity.test.ts
@@ -173,6 +173,45 @@ ruleTester.run("max-complexity", rule, {
       errors: [{ messageId: "maxComplexity" as const }],
     },
     {
+      code: `function countClassicFor() {
+        for (let i = 0; i < 10; i++) {
+          consume(i);
+        }
+      }`,
+      options: [{ max: 1 }],
+      errors: [{ messageId: "maxComplexity" as const }],
+    },
+    {
+      code: `function countLogicalOr(left, right) {
+        return left || right;
+      }`,
+      options: [{ max: 1 }],
+      errors: [{ messageId: "maxComplexity" as const }],
+    },
+    {
+      code: `function countLogicalNullish(left, right) {
+        return left ?? right;
+      }`,
+      options: [{ max: 1 }],
+      errors: [{ messageId: "maxComplexity" as const }],
+    },
+    {
+      code: `function countLogicalAndAssign(value) {
+        value &&= 1;
+        return value;
+      }`,
+      options: [{ max: 1 }],
+      errors: [{ messageId: "maxComplexity" as const }],
+    },
+    {
+      code: `function countLogicalNullishAssign(value) {
+        value ??= 1;
+        return value;
+      }`,
+      options: [{ max: 1 }],
+      errors: [{ messageId: "maxComplexity" as const }],
+    },
+    {
       code: `function countOptionalMember(input) {
         return input?.value;
       }`,


### PR DESCRIPTION
## Summary

Fills the 5 missing operator-specific test cases identified in #116.

### Added test cases

| Test name | Operator | AST listener |
|---|---|---|
| countClassicFor | Classic for loop | ForStatement |
| countLogicalOr | \|\| | LogicalExpression |
| countLogicalNullish | ?? | LogicalExpression |
| countLogicalAndAssign | &&= | AssignmentExpression |
| countLogicalNullishAssign | ??= | AssignmentExpression |

### Verification

- All 34 max-complexity tests pass (was 29, now 34)
- Full suite: 684/684 tests pass
- npm run lint passes
- npm run build passes

Closes #116

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for the max-complexity rule to better validate detection across additional syntactic constructs, including loop patterns and logical operators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->