### PR TITLE
feat: generated instructions from active ESLint config

### DIFF
--- a/.changeset/generated-instructions.md
+++ b/.changeset/generated-instructions.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-llm-core": minor
+---
+
+Add generated instructions from active ESLint config — CLI, programmatic API, and rule metadata

--- a/README.md
+++ b/README.md
@@ -215,6 +215,67 @@ and code quality. Key papers:
 
 - [Technical Debt in LLM Architectures](https://arxiv.org/abs/2512.04273) — 80% architectural violation rate in open-weights models; "Implementation Laziness" omits complex logic
 
+## Generated Instructions
+
+Lint rules are reactive — they fire after code is written. **Generated instructions are proactive** — they encode the same rule knowledge as imperative behavioral guidelines that shape LLM output before violations occur.
+
+Unlike static instruction files, generated instructions are:
+
+- **Personalized** — derived from your actual rule config and option values
+- **In sync** — regenerated when config changes, no drift between rules and instructions
+- **File-type-aware** — TypeScript-only rules appear in a separate section
+
+### Usage
+
+```bash
+npx eslint-plugin-llm-core generate-instructions
+```
+
+This reads your `eslint.config.*`, resolves active `llm-core` rules, and generates `.agents/linting-rules.md` with behavioral guidelines for AI coding tools.
+
+**Flags:**
+
+| Flag              | Description                                             |
+| ----------------- | ------------------------------------------------------- |
+| `--config <path>` | Specify ESLint config file path (default: auto-detect)  |
+| `--dry-run`       | Print generated content to stdout without writing files |
+
+**Example output:**
+
+```markdown
+# Coding Guidelines
+
+Generated from eslint-plugin-llm-core configuration.
+
+## All Files
+
+- Keep functions under 50 lines — extract helpers when they grow
+- Keep cyclomatic complexity under 10 — decompose when functions get complex
+- Never leave catch blocks empty — handle, rethrow, or log the error
+- Use structured logging with static message strings; pass dynamic values as separate metadata
+
+## TypeScript Files Only
+
+- Add explicit parameter and return type annotations on all exported functions
+- Never use 'any' as a generic type argument
+- Use 'unknown' for catch parameter types, not 'any'
+```
+
+### Programmatic API
+
+```typescript
+import { generateInstructions } from "eslint-plugin-llm-core/instructions";
+
+const result = await generateInstructions({
+  configPath: "eslint.config.mjs",
+});
+
+result.content; // The generated markdown string
+result.activeRules; // Resolved rules with options and derived scope
+result.allFilesRules; // Rules applying to all files
+result.typescriptRules; // TypeScript-only rules
+```
+
 ## Agent Skills
 
 Beyond ESLint rules, this plugin ships **agent skills** — markdown instruction files that LLM agents can load when performing specific tasks. Skills complement the lint rules by catching patterns that require judgment rather than pattern matching.

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ Unlike static instruction files, generated instructions are:
 ### Usage
 
 ```bash
-npx eslint-plugin-llm-core generate-instructions
+npx generate-instructions
 ```
 
 This reads your `eslint.config.*`, resolves active `llm-core` rules, and generates `.agents/linting-rules.md` with behavioral guidelines for AI coding tools.

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ Unlike static instruction files, generated instructions are:
 ### Usage
 
 ```bash
-npx generate-instructions
+npx llm-core-instructions
 ```
 
 This reads your `eslint.config.*`, resolves active `llm-core` rules, and generates `.agents/linting-rules.md` with behavioral guidelines for AI coding tools.

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     }
   },
   "bin": {
-    "generate-instructions": "./dist/cli/generate-instructions.js"
+    "llm-core-instructions": "./dist/cli/generate-instructions.js"
   },
   "files": [
     "dist",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,15 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.js"
+    },
+    "./instructions": {
+      "types": "./dist/instructions/index.d.ts",
+      "import": "./dist/instructions/index.js",
+      "require": "./dist/instructions/index.js"
     }
+  },
+  "bin": {
+    "generate-instructions": "./dist/cli/generate-instructions.js"
   },
   "files": [
     "dist",

--- a/src/cli/generate-instructions.ts
+++ b/src/cli/generate-instructions.ts
@@ -33,7 +33,10 @@ async function main(): Promise<void> {
   console.log(`Generated ${outputPath}`);
 }
 
-main().catch((error: Error) => {
-  console.error("Error:", error.message);
+main().catch((error: unknown) => {
+  console.error(
+    "Error:",
+    error instanceof Error ? error.message : String(error),
+  );
   process.exit(1);
 });

--- a/src/cli/generate-instructions.ts
+++ b/src/cli/generate-instructions.ts
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+import fs from "fs";
+import path from "path";
+import { generateInstructions } from "../generate-instructions";
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  let configPath: string | undefined;
+  let dryRun = false;
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--config" && args[i + 1]) {
+      configPath = args[++i];
+    } else if (args[i] === "--dry-run") {
+      dryRun = true;
+    }
+  }
+
+  const result = await generateInstructions({ configPath });
+
+  if (dryRun) {
+    process.stdout.write(result.content);
+    return;
+  }
+
+  const agentsDir = path.join(process.cwd(), ".agents");
+  if (!fs.existsSync(agentsDir)) {
+    fs.mkdirSync(agentsDir, { recursive: true });
+  }
+
+  const outputPath = path.join(agentsDir, "linting-rules.md");
+  fs.writeFileSync(outputPath, result.content, "utf-8");
+  console.log(`Generated ${outputPath}`);
+}
+
+main().catch((error: Error) => {
+  console.error("Error:", error.message);
+  process.exit(1);
+});

--- a/src/generate-instructions.ts
+++ b/src/generate-instructions.ts
@@ -1,0 +1,19 @@
+import type {
+  GenerateInstructionsOptions,
+  GenerateInstructionsResult,
+} from "./instructions/types";
+import { resolveActiveRules } from "./instructions/config-resolver";
+import { generateMarkdown } from "./instructions/generator";
+
+export async function generateInstructions(
+  options?: GenerateInstructionsOptions,
+): Promise<GenerateInstructionsResult> {
+  const activeRules = await resolveActiveRules(options?.configPath);
+  const content = generateMarkdown(activeRules);
+  const allFilesRules = activeRules.filter((rule) => rule.scope === "all");
+  const typescriptRules = activeRules.filter(
+    (rule) => rule.scope === "typescript-only",
+  );
+
+  return { content, activeRules, allFilesRules, typescriptRules };
+}

--- a/src/instructions/config-resolver.ts
+++ b/src/instructions/config-resolver.ts
@@ -1,0 +1,24 @@
+import type { RuleInstruction } from "./types";
+
+function formatOptionValue(value: unknown): string {
+  if (Array.isArray(value)) {
+    return value.join(", ");
+  }
+
+  return String(value);
+}
+
+export function interpolateInstruction(
+  instruction: RuleInstruction,
+  options: Record<string, unknown>,
+): string {
+  const template = instruction.optionTemplate ?? instruction.principle;
+
+  return template.replaceAll(/\{(\w+)\}/g, (match, key: string) => {
+    if (!(key in options) || options[key] === undefined) {
+      return match;
+    }
+
+    return formatOptionValue(options[key]);
+  });
+}

--- a/src/instructions/config-resolver.ts
+++ b/src/instructions/config-resolver.ts
@@ -1,4 +1,22 @@
-import type { RuleInstruction } from "./types";
+import path from "path";
+import { loadESLint } from "eslint";
+import { ruleDefaultOptions, ruleInstructions } from "./rule-instructions";
+import type { ResolvedRule, RuleInstruction } from "./types";
+
+type ResolvedLintRule = {
+  enabled: boolean;
+  options: Record<string, unknown>;
+};
+
+type FlatESLint = new (options?: { overrideConfigFile?: string }) => {
+  calculateConfigForFile(
+    filePath: string,
+  ): Promise<{ rules?: Record<string, unknown> }>;
+};
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
 
 function formatOptionValue(value: unknown): string {
   if (Array.isArray(value)) {
@@ -8,12 +26,14 @@ function formatOptionValue(value: unknown): string {
   return String(value);
 }
 
-export function interpolateInstruction(
-  instruction: RuleInstruction,
+function getReferencedOptionKeys(template: string): string[] {
+  return [...template.matchAll(/\{(\w+)\}/g)].map((match) => match[1]);
+}
+
+function interpolateTemplate(
+  template: string,
   options: Record<string, unknown>,
 ): string {
-  const template = instruction.optionTemplate ?? instruction.principle;
-
   return template.replaceAll(/\{(\w+)\}/g, (match, key: string) => {
     if (!(key in options) || options[key] === undefined) {
       return match;
@@ -21,4 +41,122 @@ export function interpolateInstruction(
 
     return formatOptionValue(options[key]);
   });
+}
+
+function isEnabledSeverity(value: unknown): boolean {
+  return value === "warn" || value === "error" || value === 1 || value === 2;
+}
+
+function resolveLintRuleConfig(
+  ruleName: string,
+  ruleConfig: unknown,
+): ResolvedLintRule {
+  const defaultOptions = ruleDefaultOptions[ruleName] ?? {};
+
+  if (Array.isArray(ruleConfig)) {
+    const [severity, configuredOptions] = ruleConfig;
+
+    return {
+      enabled: isEnabledSeverity(severity),
+      options: isPlainObject(configuredOptions)
+        ? { ...defaultOptions, ...configuredOptions }
+        : { ...defaultOptions },
+    };
+  }
+
+  return {
+    enabled: isEnabledSeverity(ruleConfig),
+    options: { ...defaultOptions },
+  };
+}
+
+export function interpolateInstruction(
+  instruction: RuleInstruction,
+  options: Record<string, unknown>,
+): string {
+  const principleKeys = getReferencedOptionKeys(instruction.principle);
+  const templateKeys = instruction.optionTemplate
+    ? getReferencedOptionKeys(instruction.optionTemplate)
+    : principleKeys;
+  const referencedOptionCount = templateKeys.filter(
+    (key) => options[key] !== undefined,
+  ).length;
+
+  if (principleKeys.length === 0 && !instruction.optionTemplate) {
+    return instruction.principle;
+  }
+
+  if (referencedOptionCount === 0) {
+    return instruction.principle;
+  }
+
+  if (principleKeys.length > 1 && !instruction.optionTemplate) {
+    return instruction.principle;
+  }
+
+  const template = instruction.optionTemplate ?? instruction.principle;
+
+  return interpolateTemplate(template, options);
+}
+
+export async function resolveActiveRules(
+  configPath?: string,
+): Promise<ResolvedRule[]> {
+  const loadFlatESLint = loadESLint as unknown as (options: {
+    useFlatConfig: boolean;
+  }) => Promise<FlatESLint>;
+  const ESLint = await loadFlatESLint({ useFlatConfig: true });
+  const eslint = configPath
+    ? new ESLint({ overrideConfigFile: configPath })
+    : new ESLint({});
+  const cwd = process.cwd();
+
+  const jsConfig = await eslint.calculateConfigForFile(
+    path.join(cwd, "__virtual__.js"),
+  );
+  const tsConfig = await eslint.calculateConfigForFile(
+    path.join(cwd, "__virtual__.ts"),
+  );
+
+  const jsRules = (jsConfig.rules ?? {}) as Record<string, unknown>;
+  const tsRules = (tsConfig.rules ?? {}) as Record<string, unknown>;
+
+  const ruleNames = new Set(
+    [...Object.keys(jsRules), ...Object.keys(tsRules)]
+      .filter((ruleName) => ruleName.startsWith("llm-core/"))
+      .map((ruleName) => ruleName.replace(/^llm-core\//, "")),
+  );
+
+  return [...ruleNames]
+    .filter((ruleName) => ruleName in ruleInstructions)
+    .map((ruleName) => {
+      const jsRule = resolveLintRuleConfig(
+        ruleName,
+        jsRules[`llm-core/${ruleName}`],
+      );
+      const tsRule = resolveLintRuleConfig(
+        ruleName,
+        tsRules[`llm-core/${ruleName}`],
+      );
+      const enabledInJs = jsRule.enabled;
+      const enabledInTs = tsRule.enabled;
+
+      if (!enabledInJs && !enabledInTs) {
+        return null;
+      }
+
+      const scope = enabledInTs && !enabledInJs ? "typescript-only" : "all";
+      const options = enabledInJs ? jsRule.options : tsRule.options;
+
+      return {
+        name: ruleName,
+        instruction: interpolateInstruction(
+          ruleInstructions[ruleName],
+          options,
+        ),
+        scope,
+      } satisfies ResolvedRule;
+    })
+    .filter((rule): rule is ResolvedRule => rule !== null)
+    .sort((left, right) => left.name.localeCompare(right.name));
 }

--- a/src/instructions/config-resolver.ts
+++ b/src/instructions/config-resolver.ts
@@ -102,6 +102,7 @@ export function interpolateInstruction(
 export async function resolveActiveRules(
   configPath?: string,
 ): Promise<ResolvedRule[]> {
+  // ESLint types do not expose the flat-config overload; cast is safe at runtime
   const loadFlatESLint = loadESLint as unknown as (options: {
     useFlatConfig: boolean;
   }) => Promise<FlatESLint>;

--- a/src/instructions/generator.ts
+++ b/src/instructions/generator.ts
@@ -13,7 +13,7 @@ export function generateMarkdown(rules: ResolvedRule[]): string {
   let content = `# Coding Guidelines
 
 Generated from eslint-plugin-llm-core configuration.
-Regenerate with: npx eslint-plugin-llm-core generate-instructions
+Regenerate with: npx generate-instructions
 `;
 
   if (allFilesRules.length > 0) {

--- a/src/instructions/generator.ts
+++ b/src/instructions/generator.ts
@@ -13,7 +13,7 @@ export function generateMarkdown(rules: ResolvedRule[]): string {
   let content = `# Coding Guidelines
 
 Generated from eslint-plugin-llm-core configuration.
-Regenerate with: npx generate-instructions
+Regenerate with: npx llm-core-instructions
 `;
 
   if (allFilesRules.length > 0) {

--- a/src/instructions/generator.ts
+++ b/src/instructions/generator.ts
@@ -13,7 +13,7 @@ export function generateMarkdown(rules: ResolvedRule[]): string {
   let content = `# Coding Guidelines
 
 Generated from eslint-plugin-llm-core configuration.
-Regenerate with: npx generate-instructions
+Regenerate with: npx eslint-plugin-llm-core generate-instructions
 `;
 
   if (allFilesRules.length > 0) {

--- a/src/instructions/generator.ts
+++ b/src/instructions/generator.ts
@@ -1,0 +1,36 @@
+import type { ResolvedRule } from "./types";
+
+function renderRuleList(rules: ResolvedRule[]): string {
+  return rules.map((rule) => `- ${rule.instruction}`).join("\n");
+}
+
+export function generateMarkdown(rules: ResolvedRule[]): string {
+  const allFilesRules = rules.filter((rule) => rule.scope === "all");
+  const typescriptRules = rules.filter(
+    (rule) => rule.scope === "typescript-only",
+  );
+
+  let content = `# Coding Guidelines
+
+Generated from eslint-plugin-llm-core configuration.
+Regenerate with: npx generate-instructions
+`;
+
+  if (allFilesRules.length > 0) {
+    content += `
+## All Files
+
+${renderRuleList(allFilesRules)}
+`;
+  }
+
+  if (typescriptRules.length > 0) {
+    content += `
+## TypeScript Files Only
+
+${renderRuleList(typescriptRules)}
+`;
+  }
+
+  return content;
+}

--- a/src/instructions/index.ts
+++ b/src/instructions/index.ts
@@ -1,0 +1,6 @@
+export type {
+  RuleInstruction,
+  ResolvedRule,
+  GenerateInstructionsResult,
+  GenerateInstructionsOptions,
+} from "./types";

--- a/src/instructions/index.ts
+++ b/src/instructions/index.ts
@@ -1,3 +1,4 @@
+export { generateInstructions } from "../generate-instructions";
 export type {
   RuleInstruction,
   ResolvedRule,

--- a/src/instructions/rule-instructions.ts
+++ b/src/instructions/rule-instructions.ts
@@ -1,0 +1,149 @@
+import type { RuleInstruction } from "./types";
+import consistentCatchParamNameRule, {
+  instruction as consistentCatchParamName,
+} from "../rules/consistent-catch-param-name";
+import explicitExportTypesRule, {
+  instruction as explicitExportTypes,
+} from "../rules/explicit-export-types";
+import filenameMatchExportRule, {
+  instruction as filenameMatchExport,
+} from "../rules/filename-match-export";
+import maxComplexityRule, {
+  instruction as maxComplexity,
+} from "../rules/max-complexity";
+import maxFileLengthRule, {
+  instruction as maxFileLength,
+} from "../rules/max-file-length";
+import maxFunctionLengthRule, {
+  instruction as maxFunctionLength,
+} from "../rules/max-function-length";
+import maxNestingDepthRule, {
+  instruction as maxNestingDepth,
+} from "../rules/max-nesting-depth";
+import maxParamsRule, { instruction as maxParams } from "../rules/max-params";
+import namingConventionsRule, {
+  instruction as namingConventions,
+} from "../rules/naming-conventions";
+import noAnyInGenericRule, {
+  instruction as noAnyInGeneric,
+} from "../rules/no-any-in-generic";
+import noAsyncArrayCallbacksRule, {
+  instruction as noAsyncArrayCallbacks,
+} from "../rules/no-async-array-callbacks";
+import noCommentedOutCodeRule, {
+  instruction as noCommentedOutCode,
+} from "../rules/no-commented-out-code";
+import noEmptyCatchRule, {
+  instruction as noEmptyCatch,
+} from "../rules/no-empty-catch";
+import noExportedFunctionExpressionsRule, {
+  instruction as noExportedFunctionExpressions,
+} from "../rules/no-exported-function-expressions";
+import noInlineDisableRule, {
+  instruction as noInlineDisable,
+} from "../rules/no-inline-disable";
+import noLlmArtifactsRule, {
+  instruction as noLlmArtifacts,
+} from "../rules/no-llm-artifacts";
+import noMagicNumbersRule, {
+  instruction as noMagicNumbers,
+} from "../rules/no-magic-numbers";
+import noRedundantLogicRule, {
+  instruction as noRedundantLogic,
+} from "../rules/no-redundant-logic";
+import noSwallowedErrorsRule, {
+  instruction as noSwallowedErrors,
+} from "../rules/no-swallowed-errors";
+import noTypeAssertionAnyRule, {
+  instruction as noTypeAssertionAny,
+} from "../rules/no-type-assertion-any";
+import preferEarlyReturnRule, {
+  instruction as preferEarlyReturn,
+} from "../rules/prefer-early-return";
+import preferUnknownInCatchRule, {
+  instruction as preferUnknownInCatch,
+} from "../rules/prefer-unknown-in-catch";
+import structuredLoggingRule, {
+  instruction as structuredLogging,
+} from "../rules/structured-logging";
+import throwErrorObjectsRule, {
+  instruction as throwErrorObjects,
+} from "../rules/throw-error-objects";
+
+type RuleModuleWithDefaults = {
+  defaultOptions?: readonly unknown[];
+};
+
+function getDefaultOptions(
+  rule: RuleModuleWithDefaults,
+): Record<string, unknown> {
+  const [firstOption] = rule.defaultOptions ?? [];
+
+  if (
+    firstOption &&
+    typeof firstOption === "object" &&
+    !Array.isArray(firstOption)
+  ) {
+    return { ...(firstOption as Record<string, unknown>) };
+  }
+
+  return {};
+}
+
+export const ruleInstructions: Record<string, RuleInstruction> = {
+  "consistent-catch-param-name": consistentCatchParamName,
+  "explicit-export-types": explicitExportTypes,
+  "filename-match-export": filenameMatchExport,
+  "max-complexity": maxComplexity,
+  "max-file-length": maxFileLength,
+  "max-function-length": maxFunctionLength,
+  "max-nesting-depth": maxNestingDepth,
+  "max-params": maxParams,
+  "naming-conventions": namingConventions,
+  "no-any-in-generic": noAnyInGeneric,
+  "no-async-array-callbacks": noAsyncArrayCallbacks,
+  "no-commented-out-code": noCommentedOutCode,
+  "no-empty-catch": noEmptyCatch,
+  "no-exported-function-expressions": noExportedFunctionExpressions,
+  "no-inline-disable": noInlineDisable,
+  "no-llm-artifacts": noLlmArtifacts,
+  "no-magic-numbers": noMagicNumbers,
+  "no-redundant-logic": noRedundantLogic,
+  "no-swallowed-errors": noSwallowedErrors,
+  "no-type-assertion-any": noTypeAssertionAny,
+  "prefer-early-return": preferEarlyReturn,
+  "prefer-unknown-in-catch": preferUnknownInCatch,
+  "structured-logging": structuredLogging,
+  "throw-error-objects": throwErrorObjects,
+};
+
+export const ruleDefaultOptions: Record<string, Record<string, unknown>> = {
+  "consistent-catch-param-name": getDefaultOptions(
+    consistentCatchParamNameRule,
+  ),
+  "explicit-export-types": getDefaultOptions(explicitExportTypesRule),
+  "filename-match-export": getDefaultOptions(filenameMatchExportRule),
+  "max-complexity": getDefaultOptions(maxComplexityRule),
+  "max-file-length": getDefaultOptions(maxFileLengthRule),
+  "max-function-length": getDefaultOptions(maxFunctionLengthRule),
+  "max-nesting-depth": getDefaultOptions(maxNestingDepthRule),
+  "max-params": getDefaultOptions(maxParamsRule),
+  "naming-conventions": getDefaultOptions(namingConventionsRule),
+  "no-any-in-generic": getDefaultOptions(noAnyInGenericRule),
+  "no-async-array-callbacks": getDefaultOptions(noAsyncArrayCallbacksRule),
+  "no-commented-out-code": getDefaultOptions(noCommentedOutCodeRule),
+  "no-empty-catch": getDefaultOptions(noEmptyCatchRule),
+  "no-exported-function-expressions": getDefaultOptions(
+    noExportedFunctionExpressionsRule,
+  ),
+  "no-inline-disable": getDefaultOptions(noInlineDisableRule),
+  "no-llm-artifacts": getDefaultOptions(noLlmArtifactsRule),
+  "no-magic-numbers": getDefaultOptions(noMagicNumbersRule),
+  "no-redundant-logic": getDefaultOptions(noRedundantLogicRule),
+  "no-swallowed-errors": getDefaultOptions(noSwallowedErrorsRule),
+  "no-type-assertion-any": getDefaultOptions(noTypeAssertionAnyRule),
+  "prefer-early-return": getDefaultOptions(preferEarlyReturnRule),
+  "prefer-unknown-in-catch": getDefaultOptions(preferUnknownInCatchRule),
+  "structured-logging": getDefaultOptions(structuredLoggingRule),
+  "throw-error-objects": getDefaultOptions(throwErrorObjectsRule),
+};

--- a/src/instructions/types.ts
+++ b/src/instructions/types.ts
@@ -1,3 +1,10 @@
+/**
+ * Behavioral guideline for a lint rule, included in generated instruction files.
+ *
+ * Every `{key}` placeholder in `principle` or `optionTemplate` MUST have a
+ * corresponding entry in the rule's `defaultOptions` (or the key will be emitted
+ * verbatim when no option is configured).
+ */
 export interface RuleInstruction {
   principle: string;
   optionTemplate?: string;

--- a/src/instructions/types.ts
+++ b/src/instructions/types.ts
@@ -1,0 +1,21 @@
+export interface RuleInstruction {
+  principle: string;
+  optionTemplate?: string;
+}
+
+export interface ResolvedRule {
+  name: string;
+  instruction: string;
+  scope: "all" | "typescript-only";
+}
+
+export interface GenerateInstructionsResult {
+  content: string;
+  activeRules: ResolvedRule[];
+  allFilesRules: ResolvedRule[];
+  typescriptRules: ResolvedRule[];
+}
+
+export interface GenerateInstructionsOptions {
+  configPath?: string;
+}

--- a/src/rules/consistent-catch-param-name.ts
+++ b/src/rules/consistent-catch-param-name.ts
@@ -10,11 +10,6 @@ type Options = [
   },
 ];
 
-export const instruction: RuleInstruction = {
-  principle: "Name all catch parameters '{name}' consistently",
-  optionTemplate: "Name all catch parameters '{name}' consistently",
-};
-
 export default createRule<Options, MessageIds>({
   name: "consistent-catch-param-name",
   meta: {
@@ -114,3 +109,8 @@ export default createRule<Options, MessageIds>({
     };
   },
 });
+
+export const instruction: RuleInstruction = {
+  principle: "Name all catch parameters '{name}' consistently",
+  optionTemplate: "Name all catch parameters '{name}' consistently",
+};

--- a/src/rules/consistent-catch-param-name.ts
+++ b/src/rules/consistent-catch-param-name.ts
@@ -1,4 +1,5 @@
 import { AST_NODE_TYPES, TSESTree } from "@typescript-eslint/utils";
+import type { RuleInstruction } from "../instructions/types";
 import { createRule } from "../utils/create-rule";
 
 type MessageIds = "consistentCatchParamName" | "renameCatchParam";
@@ -8,6 +9,11 @@ type Options = [
     name?: string;
   },
 ];
+
+export const instruction: RuleInstruction = {
+  principle: "Name all catch parameters '{name}' consistently",
+  optionTemplate: "Name all catch parameters '{name}' consistently",
+};
 
 export default createRule<Options, MessageIds>({
   name: "consistent-catch-param-name",

--- a/src/rules/consistent-catch-param-name.ts
+++ b/src/rules/consistent-catch-param-name.ts
@@ -112,5 +112,4 @@ export default createRule<Options, MessageIds>({
 
 export const instruction: RuleInstruction = {
   principle: "Name all catch parameters '{name}' consistently",
-  optionTemplate: "Name all catch parameters '{name}' consistently",
 };

--- a/src/rules/explicit-export-types.ts
+++ b/src/rules/explicit-export-types.ts
@@ -1,7 +1,13 @@
 import { AST_NODE_TYPES, TSESTree } from "@typescript-eslint/utils";
+import type { RuleInstruction } from "../instructions/types";
 import { createRule } from "../utils/create-rule";
 
 type MessageIds = "missingParamType" | "missingReturnType";
+
+export const instruction: RuleInstruction = {
+  principle:
+    "Add explicit parameter and return type annotations on all exported functions",
+};
 
 export default createRule<[], MessageIds>({
   name: "explicit-export-types",

--- a/src/rules/explicit-export-types.ts
+++ b/src/rules/explicit-export-types.ts
@@ -4,11 +4,6 @@ import { createRule } from "../utils/create-rule";
 
 type MessageIds = "missingParamType" | "missingReturnType";
 
-export const instruction: RuleInstruction = {
-  principle:
-    "Add explicit parameter and return type annotations on all exported functions",
-};
-
 export default createRule<[], MessageIds>({
   name: "explicit-export-types",
   meta: {
@@ -200,3 +195,8 @@ export default createRule<[], MessageIds>({
     };
   },
 });
+
+export const instruction: RuleInstruction = {
+  principle:
+    "Add explicit parameter and return type annotations on all exported functions",
+};

--- a/src/rules/filename-match-export.ts
+++ b/src/rules/filename-match-export.ts
@@ -1,8 +1,14 @@
 import path from "path";
 import { AST_NODE_TYPES, TSESTree } from "@typescript-eslint/utils";
+import type { RuleInstruction } from "../instructions/types";
 import { createRule } from "../utils/create-rule";
 
 type MessageIds = "filenameMismatch";
+
+export const instruction: RuleInstruction = {
+  principle:
+    "Name files to match their primary export — file names should reflect what they contain",
+};
 
 const IGNORED_FILENAMES = new Set([
   "index",

--- a/src/rules/filename-match-export.ts
+++ b/src/rules/filename-match-export.ts
@@ -5,11 +5,6 @@ import { createRule } from "../utils/create-rule";
 
 type MessageIds = "filenameMismatch";
 
-export const instruction: RuleInstruction = {
-  principle:
-    "Name files to match their primary export — file names should reflect what they contain",
-};
-
 const IGNORED_FILENAMES = new Set([
   "index",
   "types",
@@ -250,3 +245,8 @@ export default createRule<[], MessageIds>({
     };
   },
 });
+
+export const instruction: RuleInstruction = {
+  principle:
+    "Name files to match their primary export — file names should reflect what they contain",
+};

--- a/src/rules/max-complexity.ts
+++ b/src/rules/max-complexity.ts
@@ -1,6 +1,7 @@
 import type { Rule } from "eslint";
 import path from "path";
 import { AST_NODE_TYPES, TSESLint, TSESTree } from "@typescript-eslint/utils";
+import type { RuleInstruction } from "../instructions/types";
 import { createRule } from "../utils/create-rule";
 
 type MessageIds = "maxComplexity";
@@ -11,6 +12,11 @@ type Options = [
     skipTestFiles?: boolean;
   },
 ];
+
+export const instruction: RuleInstruction = {
+  principle:
+    "Keep cyclomatic complexity under {max} — decompose when functions get complex",
+};
 
 export default createRule<Options, MessageIds>({
   name: "max-complexity",

--- a/src/rules/max-complexity.ts
+++ b/src/rules/max-complexity.ts
@@ -13,11 +13,6 @@ type Options = [
   },
 ];
 
-export const instruction: RuleInstruction = {
-  principle:
-    "Keep cyclomatic complexity under {max} — decompose when functions get complex",
-};
-
 export default createRule<Options, MessageIds>({
   name: "max-complexity",
   meta: {
@@ -253,3 +248,8 @@ export default createRule<Options, MessageIds>({
     return listeners;
   },
 });
+
+export const instruction: RuleInstruction = {
+  principle:
+    "Keep cyclomatic complexity under {max} — decompose when functions get complex",
+};

--- a/src/rules/max-file-length.ts
+++ b/src/rules/max-file-length.ts
@@ -1,4 +1,5 @@
 import path from "path";
+import type { RuleInstruction } from "../instructions/types";
 import { createRule } from "../utils/create-rule";
 
 type MessageIds = "maxFileLength";
@@ -10,6 +11,11 @@ type Options = [
     skipTestFiles?: boolean;
   },
 ];
+
+export const instruction: RuleInstruction = {
+  principle:
+    "Keep files under {max} lines — split modules when they exceed this",
+};
 
 export default createRule<Options, MessageIds>({
   name: "max-file-length",

--- a/src/rules/max-file-length.ts
+++ b/src/rules/max-file-length.ts
@@ -12,11 +12,6 @@ type Options = [
   },
 ];
 
-export const instruction: RuleInstruction = {
-  principle:
-    "Keep files under {max} lines — split modules when they exceed this",
-};
-
 export default createRule<Options, MessageIds>({
   name: "max-file-length",
   meta: {
@@ -100,3 +95,8 @@ export default createRule<Options, MessageIds>({
     };
   },
 });
+
+export const instruction: RuleInstruction = {
+  principle:
+    "Keep files under {max} lines — split modules when they exceed this",
+};

--- a/src/rules/max-function-length.ts
+++ b/src/rules/max-function-length.ts
@@ -13,11 +13,6 @@ type Options = [
   },
 ];
 
-export const instruction: RuleInstruction = {
-  principle:
-    "Keep functions under {max} lines — extract helpers when they grow",
-};
-
 export default createRule<Options, MessageIds>({
   name: "max-function-length",
   meta: {
@@ -164,3 +159,8 @@ export default createRule<Options, MessageIds>({
     };
   },
 });
+
+export const instruction: RuleInstruction = {
+  principle:
+    "Keep functions under {max} lines — extract helpers when they grow",
+};

--- a/src/rules/max-function-length.ts
+++ b/src/rules/max-function-length.ts
@@ -1,5 +1,6 @@
 import path from "path";
 import { AST_NODE_TYPES, TSESTree } from "@typescript-eslint/utils";
+import type { RuleInstruction } from "../instructions/types";
 import { createRule } from "../utils/create-rule";
 
 type MessageIds = "maxFunctionLength";
@@ -11,6 +12,11 @@ type Options = [
     skipTestFiles?: boolean;
   },
 ];
+
+export const instruction: RuleInstruction = {
+  principle:
+    "Keep functions under {max} lines — extract helpers when they grow",
+};
 
 export default createRule<Options, MessageIds>({
   name: "max-function-length",

--- a/src/rules/max-nesting-depth.ts
+++ b/src/rules/max-nesting-depth.ts
@@ -10,11 +10,6 @@ type Options = [
   },
 ];
 
-export const instruction: RuleInstruction = {
-  principle:
-    "Keep nesting depth under {max} — use guard clauses and helper functions",
-};
-
 export default createRule<Options, MessageIds>({
   name: "max-nesting-depth",
   meta: {
@@ -152,3 +147,8 @@ export default createRule<Options, MessageIds>({
     };
   },
 });
+
+export const instruction: RuleInstruction = {
+  principle:
+    "Keep nesting depth under {max} — use guard clauses and helper functions",
+};

--- a/src/rules/max-nesting-depth.ts
+++ b/src/rules/max-nesting-depth.ts
@@ -1,4 +1,5 @@
 import { AST_NODE_TYPES, TSESTree } from "@typescript-eslint/utils";
+import type { RuleInstruction } from "../instructions/types";
 import { createRule } from "../utils/create-rule";
 
 type MessageIds = "maxNestingDepth";
@@ -8,6 +9,11 @@ type Options = [
     max?: number;
   },
 ];
+
+export const instruction: RuleInstruction = {
+  principle:
+    "Keep nesting depth under {max} — use guard clauses and helper functions",
+};
 
 export default createRule<Options, MessageIds>({
   name: "max-nesting-depth",

--- a/src/rules/max-params.ts
+++ b/src/rules/max-params.ts
@@ -12,13 +12,6 @@ type Options = [
   },
 ];
 
-export const instruction: RuleInstruction = {
-  principle:
-    "Limit function parameters to {max} — use object parameter patterns when more are needed",
-  optionTemplate:
-    "Limit function parameters to {max} (constructors: {maxConstructor}) — use object parameter patterns",
-};
-
 export default createRule<Options, MessageIds>({
   name: "max-params",
   meta: {
@@ -266,3 +259,10 @@ export default createRule<Options, MessageIds>({
     };
   },
 });
+
+export const instruction: RuleInstruction = {
+  principle:
+    "Limit function parameters to {max} — use object parameter patterns when more are needed",
+  optionTemplate:
+    "Limit function parameters to {max} (constructors: {maxConstructor}) — use object parameter patterns",
+};

--- a/src/rules/max-params.ts
+++ b/src/rules/max-params.ts
@@ -1,4 +1,5 @@
 import { AST_NODE_TYPES, TSESTree } from "@typescript-eslint/utils";
+import type { RuleInstruction } from "../instructions/types";
 import { createRule } from "../utils/create-rule";
 
 type MessageIds = "maxParams";
@@ -10,6 +11,13 @@ type Options = [
     maxInternal?: number;
   },
 ];
+
+export const instruction: RuleInstruction = {
+  principle:
+    "Limit function parameters to {max} — use object parameter patterns when more are needed",
+  optionTemplate:
+    "Limit function parameters to {max} (constructors: {maxConstructor}) — use object parameter patterns",
+};
 
 export default createRule<Options, MessageIds>({
   name: "max-params",

--- a/src/rules/naming-conventions.ts
+++ b/src/rules/naming-conventions.ts
@@ -4,11 +4,6 @@ import { createRule } from "../utils/create-rule";
 
 type MessageIds = "missingBasePrefix" | "missingErrorSuffix";
 
-export const instruction: RuleInstruction = {
-  principle:
-    "Use 'Base' prefix for abstract classes and 'Error' suffix for error classes",
-};
-
 export default createRule<[], MessageIds>({
   name: "naming-conventions",
   meta: {
@@ -75,6 +70,11 @@ export default createRule<[], MessageIds>({
     };
   },
 });
+
+export const instruction: RuleInstruction = {
+  principle:
+    "Use 'Base' prefix for abstract classes and 'Error' suffix for error classes",
+};
 
 function getSuperClassName(
   node: TSESTree.LeftHandSideExpression,

--- a/src/rules/naming-conventions.ts
+++ b/src/rules/naming-conventions.ts
@@ -1,7 +1,13 @@
 import { AST_NODE_TYPES, TSESTree } from "@typescript-eslint/utils";
+import type { RuleInstruction } from "../instructions/types";
 import { createRule } from "../utils/create-rule";
 
 type MessageIds = "missingBasePrefix" | "missingErrorSuffix";
+
+export const instruction: RuleInstruction = {
+  principle:
+    "Use 'Base' prefix for abstract classes and 'Error' suffix for error classes",
+};
 
 export default createRule<[], MessageIds>({
   name: "naming-conventions",

--- a/src/rules/no-any-in-generic.ts
+++ b/src/rules/no-any-in-generic.ts
@@ -4,10 +4,6 @@ import { createRule } from "../utils/create-rule";
 
 type MessageIds = "noAnyInGeneric";
 
-export const instruction: RuleInstruction = {
-  principle: "Never use 'any' as a generic type argument",
-};
-
 export default createRule<[], MessageIds>({
   name: "no-any-in-generic",
   meta: {
@@ -95,3 +91,7 @@ export default createRule<[], MessageIds>({
     };
   },
 });
+
+export const instruction: RuleInstruction = {
+  principle: "Never use 'any' as a generic type argument",
+};

--- a/src/rules/no-any-in-generic.ts
+++ b/src/rules/no-any-in-generic.ts
@@ -1,7 +1,12 @@
 import { AST_NODE_TYPES, TSESTree } from "@typescript-eslint/utils";
+import type { RuleInstruction } from "../instructions/types";
 import { createRule } from "../utils/create-rule";
 
 type MessageIds = "noAnyInGeneric";
+
+export const instruction: RuleInstruction = {
+  principle: "Never use 'any' as a generic type argument",
+};
 
 export default createRule<[], MessageIds>({
   name: "no-any-in-generic",

--- a/src/rules/no-async-array-callbacks.ts
+++ b/src/rules/no-async-array-callbacks.ts
@@ -1,7 +1,13 @@
 import { AST_NODE_TYPES, TSESTree } from "@typescript-eslint/utils";
+import type { RuleInstruction } from "../instructions/types";
 import { createRule } from "../utils/create-rule";
 
 type MessageIds = "noAsyncArrayCallback" | "noAsyncMapCallback";
+
+export const instruction: RuleInstruction = {
+  principle:
+    "Don't pass async callbacks to array methods that don't await results",
+};
 
 // Array methods where async callbacks are almost always a bug — the return
 // value of the callback is either ignored or used in a boolean/accumulator

--- a/src/rules/no-async-array-callbacks.ts
+++ b/src/rules/no-async-array-callbacks.ts
@@ -4,11 +4,6 @@ import { createRule } from "../utils/create-rule";
 
 type MessageIds = "noAsyncArrayCallback" | "noAsyncMapCallback";
 
-export const instruction: RuleInstruction = {
-  principle:
-    "Don't pass async callbacks to array methods that don't await results",
-};
-
 // Array methods where async callbacks are almost always a bug — the return
 // value of the callback is either ignored or used in a boolean/accumulator
 // context that doesn't understand Promises.
@@ -219,3 +214,8 @@ export default createRule<[], MessageIds>({
     };
   },
 });
+
+export const instruction: RuleInstruction = {
+  principle:
+    "Don't pass async callbacks to array methods that don't await results",
+};

--- a/src/rules/no-commented-out-code.ts
+++ b/src/rules/no-commented-out-code.ts
@@ -1,6 +1,11 @@
+import type { RuleInstruction } from "../instructions/types";
 import { createRule } from "../utils/create-rule";
 
 type MessageIds = "noCommentedOutCode";
+
+export const instruction: RuleInstruction = {
+  principle: "No commented-out code — delete it, git preserves history",
+};
 
 // Patterns that strongly indicate commented-out code
 const CODE_PATTERNS = [

--- a/src/rules/no-commented-out-code.ts
+++ b/src/rules/no-commented-out-code.ts
@@ -3,10 +3,6 @@ import { createRule } from "../utils/create-rule";
 
 type MessageIds = "noCommentedOutCode";
 
-export const instruction: RuleInstruction = {
-  principle: "No commented-out code — delete it, git preserves history",
-};
-
 // Patterns that strongly indicate commented-out code
 const CODE_PATTERNS = [
   // Variable declarations
@@ -136,3 +132,7 @@ export default createRule<[], MessageIds>({
     };
   },
 });
+
+export const instruction: RuleInstruction = {
+  principle: "No commented-out code — delete it, git preserves history",
+};

--- a/src/rules/no-empty-catch.ts
+++ b/src/rules/no-empty-catch.ts
@@ -1,7 +1,13 @@
 import { TSESTree } from "@typescript-eslint/utils";
+import type { RuleInstruction } from "../instructions/types";
 import { createRule } from "../utils/create-rule";
 
 type MessageIds = "noEmptyCatch";
+
+export const instruction: RuleInstruction = {
+  principle:
+    "Never leave catch blocks empty — handle, rethrow, or log the error",
+};
 
 export default createRule<[], MessageIds>({
   name: "no-empty-catch",

--- a/src/rules/no-empty-catch.ts
+++ b/src/rules/no-empty-catch.ts
@@ -4,11 +4,6 @@ import { createRule } from "../utils/create-rule";
 
 type MessageIds = "noEmptyCatch";
 
-export const instruction: RuleInstruction = {
-  principle:
-    "Never leave catch blocks empty — handle, rethrow, or log the error",
-};
-
 export default createRule<[], MessageIds>({
   name: "no-empty-catch",
   meta: {
@@ -56,3 +51,8 @@ export default createRule<[], MessageIds>({
     };
   },
 });
+
+export const instruction: RuleInstruction = {
+  principle:
+    "Never leave catch blocks empty — handle, rethrow, or log the error",
+};

--- a/src/rules/no-exported-function-expressions.ts
+++ b/src/rules/no-exported-function-expressions.ts
@@ -1,4 +1,5 @@
 import { AST_NODE_TYPES, TSESTree } from "@typescript-eslint/utils";
+import type { RuleInstruction } from "../instructions/types";
 import { createRule } from "../utils/create-rule";
 
 type MessageIds =
@@ -11,6 +12,11 @@ type FuncNode =
   | TSESTree.ArrowFunctionExpression
   | TSESTree.FunctionExpression
   | TSESTree.FunctionDeclaration;
+
+export const instruction: RuleInstruction = {
+  principle:
+    "Use function declarations for all exports — 'export function foo()' not 'export const foo = () =>'",
+};
 
 export default createRule<[], MessageIds>({
   name: "no-exported-function-expressions",

--- a/src/rules/no-exported-function-expressions.ts
+++ b/src/rules/no-exported-function-expressions.ts
@@ -13,11 +13,6 @@ type FuncNode =
   | TSESTree.FunctionExpression
   | TSESTree.FunctionDeclaration;
 
-export const instruction: RuleInstruction = {
-  principle:
-    "Use function declarations for all exports — 'export function foo()' not 'export const foo = () =>'",
-};
-
 export default createRule<[], MessageIds>({
   name: "no-exported-function-expressions",
   meta: {
@@ -171,3 +166,8 @@ export default createRule<[], MessageIds>({
     };
   },
 });
+
+export const instruction: RuleInstruction = {
+  principle:
+    "Use function declarations for all exports — 'export function foo()' not 'export const foo = () =>'",
+};

--- a/src/rules/no-inline-disable.ts
+++ b/src/rules/no-inline-disable.ts
@@ -3,10 +3,6 @@ import { createRule } from "../utils/create-rule";
 
 type MessageIds = "noInlineDisable";
 
-export const instruction: RuleInstruction = {
-  principle: "No eslint-disable comments — fix the underlying issue instead",
-};
-
 export default createRule<[], MessageIds>({
   name: "no-inline-disable",
   meta: {
@@ -56,3 +52,7 @@ export default createRule<[], MessageIds>({
     return {};
   },
 });
+
+export const instruction: RuleInstruction = {
+  principle: "No eslint-disable comments — fix the underlying issue instead",
+};

--- a/src/rules/no-inline-disable.ts
+++ b/src/rules/no-inline-disable.ts
@@ -1,6 +1,11 @@
+import type { RuleInstruction } from "../instructions/types";
 import { createRule } from "../utils/create-rule";
 
 type MessageIds = "noInlineDisable";
+
+export const instruction: RuleInstruction = {
+  principle: "No eslint-disable comments — fix the underlying issue instead",
+};
 
 export default createRule<[], MessageIds>({
   name: "no-inline-disable",

--- a/src/rules/no-llm-artifacts.ts
+++ b/src/rules/no-llm-artifacts.ts
@@ -4,11 +4,6 @@ import { createRule } from "../utils/create-rule";
 
 type MessageIds = "noLlmArtifact" | "notImplementedStub";
 
-export const instruction: RuleInstruction = {
-  principle:
-    "No LLM placeholder comments or incomplete code markers — write the actual implementation",
-};
-
 /**
  * Patterns that indicate LLM placeholder comments.
  * Each regex is tested against the trimmed comment text.
@@ -147,3 +142,8 @@ export default createRule<[], MessageIds>({
     };
   },
 });
+
+export const instruction: RuleInstruction = {
+  principle:
+    "No LLM placeholder comments or incomplete code markers — write the actual implementation",
+};

--- a/src/rules/no-llm-artifacts.ts
+++ b/src/rules/no-llm-artifacts.ts
@@ -1,7 +1,13 @@
 import { AST_NODE_TYPES, TSESTree } from "@typescript-eslint/utils";
+import type { RuleInstruction } from "../instructions/types";
 import { createRule } from "../utils/create-rule";
 
 type MessageIds = "noLlmArtifact" | "notImplementedStub";
+
+export const instruction: RuleInstruction = {
+  principle:
+    "No LLM placeholder comments or incomplete code markers — write the actual implementation",
+};
 
 /**
  * Patterns that indicate LLM placeholder comments.

--- a/src/rules/no-magic-numbers.ts
+++ b/src/rules/no-magic-numbers.ts
@@ -16,12 +16,6 @@ type Options = [
   },
 ];
 
-export const instruction: RuleInstruction = {
-  principle: "Extract named constants for all magic numbers",
-  optionTemplate:
-    "Extract named constants for magic numbers (ignore: {ignore})",
-};
-
 const DEFAULT_IGNORE = [0, 1, -1, 2];
 
 export default createRule<Options, MessageIds>({
@@ -243,3 +237,9 @@ export default createRule<Options, MessageIds>({
     };
   },
 });
+
+export const instruction: RuleInstruction = {
+  principle: "Extract named constants for all magic numbers",
+  optionTemplate:
+    "Extract named constants for magic numbers (ignore: {ignore})",
+};

--- a/src/rules/no-magic-numbers.ts
+++ b/src/rules/no-magic-numbers.ts
@@ -1,5 +1,6 @@
 import path from "path";
 import { AST_NODE_TYPES, TSESTree } from "@typescript-eslint/utils";
+import type { RuleInstruction } from "../instructions/types";
 import { createRule } from "../utils/create-rule";
 
 type MessageIds = "noMagicNumber";
@@ -14,6 +15,12 @@ type Options = [
     ignoreObjectProperties?: boolean;
   },
 ];
+
+export const instruction: RuleInstruction = {
+  principle: "Extract named constants for all magic numbers",
+  optionTemplate:
+    "Extract named constants for magic numbers (ignore: {ignore})",
+};
 
 const DEFAULT_IGNORE = [0, 1, -1, 2];
 

--- a/src/rules/no-redundant-logic.ts
+++ b/src/rules/no-redundant-logic.ts
@@ -12,10 +12,6 @@ type MessageIds =
   | "ifElseBooleanLiteral"
   | "ifElseBooleanLiteralSuggest";
 
-export const instruction: RuleInstruction = {
-  principle: "Eliminate redundant boolean logic and unnecessary control flow",
-};
-
 function isBooleanLiteral(
   node: TSESTree.Node,
 ): node is TSESTree.Literal & { value: boolean } {
@@ -419,3 +415,7 @@ export default createRule<[], MessageIds>({
     };
   },
 });
+
+export const instruction: RuleInstruction = {
+  principle: "Eliminate redundant boolean logic and unnecessary control flow",
+};

--- a/src/rules/no-redundant-logic.ts
+++ b/src/rules/no-redundant-logic.ts
@@ -1,4 +1,5 @@
 import { AST_NODE_TYPES, TSESTree } from "@typescript-eslint/utils";
+import type { RuleInstruction } from "../instructions/types";
 import { createRule } from "../utils/create-rule";
 
 type MessageIds =
@@ -10,6 +11,10 @@ type MessageIds =
   | "ternaryBooleanLiteralSuggest"
   | "ifElseBooleanLiteral"
   | "ifElseBooleanLiteralSuggest";
+
+export const instruction: RuleInstruction = {
+  principle: "Eliminate redundant boolean logic and unnecessary control flow",
+};
 
 function isBooleanLiteral(
   node: TSESTree.Node,

--- a/src/rules/no-swallowed-errors.ts
+++ b/src/rules/no-swallowed-errors.ts
@@ -1,7 +1,13 @@
 import { TSESTree } from "@typescript-eslint/utils";
+import type { RuleInstruction } from "../instructions/types";
 import { createRule } from "../utils/create-rule";
 
 type MessageIds = "noSwallowedErrors";
+
+export const instruction: RuleInstruction = {
+  principle:
+    "Don't swallow errors in catch blocks that only log to console — rethrow, return, or delegate to an error handler",
+};
 
 export default createRule<[], MessageIds>({
   name: "no-swallowed-errors",

--- a/src/rules/no-swallowed-errors.ts
+++ b/src/rules/no-swallowed-errors.ts
@@ -4,11 +4,6 @@ import { createRule } from "../utils/create-rule";
 
 type MessageIds = "noSwallowedErrors";
 
-export const instruction: RuleInstruction = {
-  principle:
-    "Don't swallow errors in catch blocks that only log to console — rethrow, return, or delegate to an error handler",
-};
-
 export default createRule<[], MessageIds>({
   name: "no-swallowed-errors",
   meta: {
@@ -92,3 +87,8 @@ export default createRule<[], MessageIds>({
     };
   },
 });
+
+export const instruction: RuleInstruction = {
+  principle:
+    "Don't swallow errors in catch blocks that only log to console — rethrow, return, or delegate to an error handler",
+};

--- a/src/rules/no-type-assertion-any.ts
+++ b/src/rules/no-type-assertion-any.ts
@@ -4,10 +4,6 @@ import { createRule } from "../utils/create-rule";
 
 type MessageIds = "noTypeAssertionAny";
 
-export const instruction: RuleInstruction = {
-  principle: "Never use type assertions to 'any'",
-};
-
 export default createRule<[], MessageIds>({
   name: "no-type-assertion-any",
   meta: {
@@ -83,3 +79,7 @@ export default createRule<[], MessageIds>({
     };
   },
 });
+
+export const instruction: RuleInstruction = {
+  principle: "Never use type assertions to 'any'",
+};

--- a/src/rules/no-type-assertion-any.ts
+++ b/src/rules/no-type-assertion-any.ts
@@ -1,7 +1,12 @@
 import { AST_NODE_TYPES, TSESTree } from "@typescript-eslint/utils";
+import type { RuleInstruction } from "../instructions/types";
 import { createRule } from "../utils/create-rule";
 
 type MessageIds = "noTypeAssertionAny";
+
+export const instruction: RuleInstruction = {
+  principle: "Never use type assertions to 'any'",
+};
 
 export default createRule<[], MessageIds>({
   name: "no-type-assertion-any",

--- a/src/rules/prefer-early-return.ts
+++ b/src/rules/prefer-early-return.ts
@@ -10,11 +10,6 @@ type Options = [
   },
 ];
 
-export const instruction: RuleInstruction = {
-  principle:
-    "Prefer early returns over wrapping function bodies in if statements",
-};
-
 function isReturnOrThrow(node: TSESTree.Statement): boolean {
   return (
     node.type === AST_NODE_TYPES.ReturnStatement ||
@@ -150,3 +145,8 @@ export default createRule<Options, MessageIds>({
     };
   },
 });
+
+export const instruction: RuleInstruction = {
+  principle:
+    "Prefer early returns over wrapping function bodies in if statements",
+};

--- a/src/rules/prefer-early-return.ts
+++ b/src/rules/prefer-early-return.ts
@@ -1,4 +1,5 @@
 import { AST_NODE_TYPES, TSESTree } from "@typescript-eslint/utils";
+import type { RuleInstruction } from "../instructions/types";
 import { createRule } from "../utils/create-rule";
 
 type MessageIds = "preferEarlyReturn";
@@ -8,6 +9,11 @@ type Options = [
     minBodyStatements?: number;
   },
 ];
+
+export const instruction: RuleInstruction = {
+  principle:
+    "Prefer early returns over wrapping function bodies in if statements",
+};
 
 function isReturnOrThrow(node: TSESTree.Statement): boolean {
   return (

--- a/src/rules/prefer-unknown-in-catch.ts
+++ b/src/rules/prefer-unknown-in-catch.ts
@@ -1,7 +1,12 @@
 import { AST_NODE_TYPES, TSESTree } from "@typescript-eslint/utils";
+import type { RuleInstruction } from "../instructions/types";
 import { createRule } from "../utils/create-rule";
 
 type MessageIds = "preferUnknownInCatch";
+
+export const instruction: RuleInstruction = {
+  principle: "Use 'unknown' for catch parameter types, not 'any'",
+};
 
 export default createRule<[], MessageIds>({
   name: "prefer-unknown-in-catch",

--- a/src/rules/prefer-unknown-in-catch.ts
+++ b/src/rules/prefer-unknown-in-catch.ts
@@ -4,10 +4,6 @@ import { createRule } from "../utils/create-rule";
 
 type MessageIds = "preferUnknownInCatch";
 
-export const instruction: RuleInstruction = {
-  principle: "Use 'unknown' for catch parameter types, not 'any'",
-};
-
 export default createRule<[], MessageIds>({
   name: "prefer-unknown-in-catch",
   meta: {
@@ -79,3 +75,7 @@ export default createRule<[], MessageIds>({
     };
   },
 });
+
+export const instruction: RuleInstruction = {
+  principle: "Use 'unknown' for catch parameter types, not 'any'",
+};

--- a/src/rules/structured-logging.ts
+++ b/src/rules/structured-logging.ts
@@ -1,4 +1,5 @@
 import { AST_NODE_TYPES, TSESTree } from "@typescript-eslint/utils";
+import type { RuleInstruction } from "../instructions/types";
 import { createRule } from "../utils/create-rule";
 
 type MessageIds = "dynamicLogMessage";
@@ -9,6 +10,11 @@ type Options = [
     logMethods?: string[];
   },
 ];
+
+export const instruction: RuleInstruction = {
+  principle:
+    "Use structured logging with static message strings; pass dynamic values as separate metadata",
+};
 
 const DEFAULT_LOG_FUNCTIONS = [
   "logError",

--- a/src/rules/structured-logging.ts
+++ b/src/rules/structured-logging.ts
@@ -11,11 +11,6 @@ type Options = [
   },
 ];
 
-export const instruction: RuleInstruction = {
-  principle:
-    "Use structured logging with static message strings; pass dynamic values as separate metadata",
-};
-
 const DEFAULT_LOG_FUNCTIONS = [
   "logError",
   "logInfo",
@@ -156,3 +151,8 @@ export default createRule<Options, MessageIds>({
     };
   },
 });
+
+export const instruction: RuleInstruction = {
+  principle:
+    "Use structured logging with static message strings; pass dynamic values as separate metadata",
+};

--- a/src/rules/throw-error-objects.ts
+++ b/src/rules/throw-error-objects.ts
@@ -1,7 +1,12 @@
 import { AST_NODE_TYPES, TSESTree } from "@typescript-eslint/utils";
+import type { RuleInstruction } from "../instructions/types";
 import { createRule } from "../utils/create-rule";
 
 type MessageIds = "throwErrorObjects";
+
+export const instruction: RuleInstruction = {
+  principle: "Always throw Error objects, never strings or plain objects",
+};
 
 export default createRule<[], MessageIds>({
   name: "throw-error-objects",

--- a/src/rules/throw-error-objects.ts
+++ b/src/rules/throw-error-objects.ts
@@ -4,10 +4,6 @@ import { createRule } from "../utils/create-rule";
 
 type MessageIds = "throwErrorObjects";
 
-export const instruction: RuleInstruction = {
-  principle: "Always throw Error objects, never strings or plain objects",
-};
-
 export default createRule<[], MessageIds>({
   name: "throw-error-objects",
   meta: {
@@ -74,3 +70,7 @@ export default createRule<[], MessageIds>({
     };
   },
 });
+
+export const instruction: RuleInstruction = {
+  principle: "Always throw Error objects, never strings or plain objects",
+};

--- a/tests/fixtures/e2e-custom.config.mjs
+++ b/tests/fixtures/e2e-custom.config.mjs
@@ -1,0 +1,31 @@
+// E2E fixture: custom config — exercises option interpolation,
+// scope separation, off-rule exclusion, and warn/error equivalence.
+import llmCore from "../../dist/index.js";
+
+export default [
+  {
+    files: ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.mjs", "**/*.cjs"],
+    plugins: { "llm-core": llmCore },
+    rules: {
+      // Custom numeric option — must appear interpolated in output
+      "llm-core/max-function-length": ["error", { max: 30 }],
+      // Warn severity — must render identically to error
+      "llm-core/no-empty-catch": "warn",
+      // Array option — must render as comma-separated list
+      "llm-core/no-magic-numbers": ["error", { ignore: [0, 1, 2, -1] }],
+      // No options — principle rendered as-is
+      "llm-core/throw-error-objects": "error",
+      // Off — must NOT appear in output
+      "llm-core/no-llm-artifacts": "off",
+      "llm-core/no-inline-disable": "off",
+      "llm-core/no-commented-out-code": "off",
+    },
+  },
+  {
+    files: ["**/*.ts", "**/*.tsx"],
+    rules: {
+      // TS-only rule — must appear in TypeScript Files Only section
+      "llm-core/explicit-export-types": "error",
+    },
+  },
+];

--- a/tests/fixtures/e2e-recommended.config.mjs
+++ b/tests/fixtures/e2e-recommended.config.mjs
@@ -1,0 +1,5 @@
+// E2E fixture: recommended config — tests full scope derivation and
+// default-option interpolation against the actual built plugin.
+import llmCore from "../../dist/index.js";
+
+export default [...llmCore.configs.recommended];

--- a/tests/instructions/config-resolver.test.ts
+++ b/tests/instructions/config-resolver.test.ts
@@ -16,9 +16,11 @@ describe("resolveActiveRules", () => {
     ESLintConstructor.mockReset();
     loadESLint.mockReset();
 
-    ESLintConstructor.mockImplementation(() => ({
-      calculateConfigForFile,
-    }));
+    ESLintConstructor.mockImplementation(function MockESLint() {
+      return {
+        calculateConfigForFile,
+      };
+    });
 
     loadESLint.mockResolvedValue(ESLintConstructor);
   });

--- a/tests/instructions/config-resolver.test.ts
+++ b/tests/instructions/config-resolver.test.ts
@@ -1,0 +1,147 @@
+import path from "path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const calculateConfigForFile = vi.hoisted(() => vi.fn());
+const ESLintConstructor = vi.hoisted(() => vi.fn());
+const loadESLint = vi.hoisted(() => vi.fn());
+
+vi.mock("eslint", () => ({
+  loadESLint,
+}));
+
+describe("resolveActiveRules", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    calculateConfigForFile.mockReset();
+    ESLintConstructor.mockReset();
+    loadESLint.mockReset();
+
+    ESLintConstructor.mockImplementation(() => ({
+      calculateConfigForFile,
+    }));
+
+    loadESLint.mockResolvedValue(ESLintConstructor);
+  });
+
+  it("resolves active rules from JavaScript and TypeScript configs", async () => {
+    calculateConfigForFile
+      .mockResolvedValueOnce({
+        rules: {
+          "llm-core/max-function-length": ["error", { max: 40 }],
+          "llm-core/explicit-export-types": "off",
+        },
+      })
+      .mockResolvedValueOnce({
+        rules: {
+          "llm-core/max-function-length": ["warn", { max: 40 }],
+          "llm-core/explicit-export-types": "error",
+        },
+      });
+
+    const { resolveActiveRules } =
+      await import("../../src/instructions/config-resolver");
+
+    await expect(resolveActiveRules("/tmp/eslint.config.mjs")).resolves.toEqual(
+      [
+        {
+          name: "explicit-export-types",
+          instruction:
+            "Add explicit parameter and return type annotations on all exported functions",
+          scope: "typescript-only",
+        },
+        {
+          name: "max-function-length",
+          instruction:
+            "Keep functions under 40 lines — extract helpers when they grow",
+          scope: "all",
+        },
+      ],
+    );
+
+    expect(loadESLint).toHaveBeenCalledWith({ useFlatConfig: true });
+    expect(ESLintConstructor).toHaveBeenCalledWith({
+      overrideConfigFile: "/tmp/eslint.config.mjs",
+    });
+    expect(calculateConfigForFile).toHaveBeenNthCalledWith(
+      1,
+      path.join(process.cwd(), "__virtual__.js"),
+    );
+    expect(calculateConfigForFile).toHaveBeenNthCalledWith(
+      2,
+      path.join(process.cwd(), "__virtual__.ts"),
+    );
+  });
+
+  it("excludes rules that are turned off", async () => {
+    calculateConfigForFile
+      .mockResolvedValueOnce({
+        rules: {
+          "llm-core/max-function-length": "off",
+        },
+      })
+      .mockResolvedValueOnce({
+        rules: {
+          "llm-core/max-function-length": "off",
+        },
+      });
+
+    const { resolveActiveRules } =
+      await import("../../src/instructions/config-resolver");
+
+    await expect(resolveActiveRules()).resolves.toEqual([]);
+  });
+
+  it("treats rules enabled only for JavaScript files as applying to all files", async () => {
+    calculateConfigForFile
+      .mockResolvedValueOnce({
+        rules: {
+          "llm-core/no-empty-catch": "warn",
+        },
+      })
+      .mockResolvedValueOnce({ rules: {} });
+
+    const { resolveActiveRules } =
+      await import("../../src/instructions/config-resolver");
+
+    await expect(resolveActiveRules()).resolves.toEqual([
+      {
+        name: "no-empty-catch",
+        instruction:
+          "Never leave catch blocks empty — handle, rethrow, or log the error",
+        scope: "all",
+      },
+    ]);
+  });
+
+  it("interpolates option values from resolved rule configuration", async () => {
+    calculateConfigForFile
+      .mockResolvedValueOnce({
+        rules: {
+          "llm-core/max-params": [
+            "error",
+            { max: 3, maxConstructor: 5, maxInternal: 4 },
+          ],
+          "llm-core/no-magic-numbers": ["warn", { ignore: [5, 10] }],
+        },
+      })
+      .mockResolvedValueOnce({ rules: {} });
+
+    const { resolveActiveRules } =
+      await import("../../src/instructions/config-resolver");
+
+    await expect(resolveActiveRules()).resolves.toEqual([
+      {
+        name: "max-params",
+        instruction:
+          "Limit function parameters to 3 (constructors: 5) — use object parameter patterns",
+        scope: "all",
+      },
+      {
+        name: "no-magic-numbers",
+        instruction:
+          "Extract named constants for magic numbers (ignore: 5, 10)",
+        scope: "all",
+      },
+    ]);
+  });
+});

--- a/tests/instructions/e2e.test.ts
+++ b/tests/instructions/e2e.test.ts
@@ -83,9 +83,7 @@ describe("e2e: generateInstructions with recommended config", () => {
   it("generates the correct header", async () => {
     const { content } = await result;
     expect(content).toContain("# Coding Guidelines");
-    expect(content).toContain(
-      "Regenerate with: npx eslint-plugin-llm-core generate-instructions",
-    );
+    expect(content).toContain("Regenerate with: npx generate-instructions");
   });
 
   it("renders no-llm-artifacts rule (present in recommended)", async () => {
@@ -148,7 +146,7 @@ describe("e2e: generateInstructions with custom config", () => {
     expect(content).toBe(`# Coding Guidelines
 
 Generated from eslint-plugin-llm-core configuration.
-Regenerate with: npx eslint-plugin-llm-core generate-instructions
+Regenerate with: npx generate-instructions
 
 ## All Files
 

--- a/tests/instructions/e2e.test.ts
+++ b/tests/instructions/e2e.test.ts
@@ -1,0 +1,227 @@
+/**
+ * End-to-end tests for generated instructions.
+ *
+ * Uses real ESLint flat config fixtures that import the actual built plugin
+ * from dist/. Exercises the full pipeline: config file → ESLint config
+ * resolution → scope derivation → option interpolation → markdown generation.
+ */
+import { execFile } from "child_process";
+import fs from "fs";
+import path from "path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { generateInstructions } from "../../src/generate-instructions";
+
+const fixturesDir = path.join(__dirname, "..", "fixtures");
+const recommendedConfig = path.join(fixturesDir, "e2e-recommended.config.mjs");
+const customConfig = path.join(fixturesDir, "e2e-custom.config.mjs");
+
+function runCli(
+  args: string[],
+  cwd?: string,
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const cliPath = path.resolve(
+    __dirname,
+    "../../dist/cli/generate-instructions.js",
+  );
+
+  return new Promise((resolve) => {
+    execFile(
+      process.execPath,
+      [cliPath, ...args],
+      { cwd: cwd ?? fixturesDir, timeout: 30_000 },
+      (error, stdout, stderr) => {
+        resolve({
+          stdout,
+          stderr,
+          exitCode: error ? 1 : 0,
+        });
+      },
+    );
+  });
+}
+
+describe("e2e: generateInstructions with recommended config", () => {
+  const result = generateInstructions({ configPath: recommendedConfig });
+
+  it("resolves all recommended rules as active", async () => {
+    const { activeRules } = await result;
+    expect(activeRules.length).toBeGreaterThanOrEqual(20);
+  });
+
+  it("places explicit-export-types in the TypeScript Files Only section", async () => {
+    const { typescriptRules } = await result;
+    const names = typescriptRules.map((r) => r.name);
+    expect(names).toContain("explicit-export-types");
+  });
+
+  it("places no-empty-catch in the All Files section", async () => {
+    const { allFilesRules } = await result;
+    const names = allFilesRules.map((r) => r.name);
+    expect(names).toContain("no-empty-catch");
+  });
+
+  it("interpolates default option values into instructions", async () => {
+    const { allFilesRules } = await result;
+    const maxFn = allFilesRules.find((r) => r.name === "max-function-length");
+    expect(maxFn).toBeDefined();
+    expect(maxFn!.instruction).toContain("under 50 lines");
+  });
+
+  it("uses default complexity value in instruction", async () => {
+    const { allFilesRules } = await result;
+    const complexity = allFilesRules.find((r) => r.name === "max-complexity");
+    expect(complexity).toBeDefined();
+    expect(complexity!.instruction).toContain("under 10");
+  });
+
+  it("generates markdown with both All Files and TypeScript Files Only sections", async () => {
+    const { content } = await result;
+    expect(content).toContain("## All Files");
+    expect(content).toContain("## TypeScript Files Only");
+  });
+
+  it("generates the correct header", async () => {
+    const { content } = await result;
+    expect(content).toContain("# Coding Guidelines");
+    expect(content).toContain(
+      "Regenerate with: npx eslint-plugin-llm-core generate-instructions",
+    );
+  });
+
+  it("renders no-llm-artifacts rule (present in recommended)", async () => {
+    const { activeRules } = await result;
+    const names = activeRules.map((r) => r.name);
+    expect(names).toContain("no-llm-artifacts");
+  });
+
+  it("produces a non-empty instruction for every active rule", async () => {
+    const { activeRules } = await result;
+    for (const rule of activeRules) {
+      expect(rule.instruction.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("e2e: generateInstructions with custom config", () => {
+  const result = generateInstructions({ configPath: customConfig });
+
+  it("interpolates custom max-function-length option", async () => {
+    const { allFilesRules } = await result;
+    const fn = allFilesRules.find((r) => r.name === "max-function-length");
+    expect(fn).toBeDefined();
+    expect(fn!.instruction).toContain("under 30 lines");
+    expect(fn!.instruction).not.toContain("{max}");
+  });
+
+  it("renders array options as comma-separated list", async () => {
+    const { allFilesRules } = await result;
+    const magic = allFilesRules.find((r) => r.name === "no-magic-numbers");
+    expect(magic).toBeDefined();
+    expect(magic!.instruction).toContain("ignore: 0, 1, 2, -1");
+  });
+
+  it("renders warn-severity rules identically to error-severity rules", async () => {
+    const { allFilesRules } = await result;
+    const emptyCatch = allFilesRules.find((r) => r.name === "no-empty-catch");
+    expect(emptyCatch).toBeDefined();
+    expect(emptyCatch!.instruction).toBe(
+      "Never leave catch blocks empty — handle, rethrow, or log the error",
+    );
+  });
+
+  it("excludes rules that are turned off", async () => {
+    const { activeRules } = await result;
+    const names = activeRules.map((r) => r.name);
+    expect(names).not.toContain("no-llm-artifacts");
+    expect(names).not.toContain("no-inline-disable");
+    expect(names).not.toContain("no-commented-out-code");
+  });
+
+  it("places explicit-export-types in TypeScript Files Only section", async () => {
+    const { typescriptRules } = await result;
+    const names = typescriptRules.map((r) => r.name);
+    expect(names).toContain("explicit-export-types");
+  });
+
+  it("produces exact expected markdown for the custom fixture", async () => {
+    const { content } = await result;
+    expect(content).toBe(`# Coding Guidelines
+
+Generated from eslint-plugin-llm-core configuration.
+Regenerate with: npx eslint-plugin-llm-core generate-instructions
+
+## All Files
+
+- Keep functions under 30 lines — extract helpers when they grow
+- Never leave catch blocks empty — handle, rethrow, or log the error
+- Extract named constants for magic numbers (ignore: 0, 1, 2, -1)
+- Always throw Error objects, never strings or plain objects
+
+## TypeScript Files Only
+
+- Add explicit parameter and return type annotations on all exported functions
+`);
+  });
+
+  it("places non-TS-only rules in All Files section", async () => {
+    const { allFilesRules } = await result;
+    const names = allFilesRules.map((r) => r.name);
+    expect(names).toContain("max-function-length");
+    expect(names).toContain("no-empty-catch");
+    expect(names).toContain("no-magic-numbers");
+    expect(names).toContain("throw-error-objects");
+  });
+});
+
+describe("e2e: CLI generate-instructions", () => {
+  const tmpDir = path.join(fixturesDir, "__tmp_cli_test__");
+
+  beforeAll(() => {
+    fs.mkdirSync(tmpDir, { recursive: true });
+  });
+
+  afterAll(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("--dry-run prints markdown to stdout", async () => {
+    const { stdout, exitCode } = await runCli([
+      "--config",
+      customConfig,
+      "--dry-run",
+    ]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("# Coding Guidelines");
+    expect(stdout).toContain("## All Files");
+    expect(stdout).toContain("under 30 lines");
+    expect(stdout).toContain("## TypeScript Files Only");
+  });
+
+  it("writes .agents/linting-rules.md to CWD when no --dry-run", async () => {
+    const { exitCode } = await runCli(["--config", customConfig], tmpDir);
+    expect(exitCode).toBe(0);
+
+    const written = path.join(tmpDir, ".agents", "linting-rules.md");
+    expect(fs.existsSync(written)).toBe(true);
+
+    const content = fs.readFileSync(written, "utf-8");
+    expect(content).toContain("# Coding Guidelines");
+    expect(content).toContain("under 30 lines");
+  });
+
+  it("overwrites existing .agents/linting-rules.md on re-run", async () => {
+    const agentsDir = path.join(tmpDir, ".agents");
+    const written = path.join(agentsDir, "linting-rules.md");
+
+    await runCli(["--config", customConfig], tmpDir);
+    expect(fs.existsSync(written)).toBe(true);
+
+    fs.writeFileSync(written, "STALE SENTINEL CONTENT", "utf-8");
+
+    await runCli(["--config", customConfig], tmpDir);
+    const overwritten = fs.readFileSync(written, "utf-8");
+    expect(overwritten).not.toBe("STALE SENTINEL CONTENT");
+    expect(overwritten).toContain("# Coding Guidelines");
+    expect(overwritten).toContain("under 30 lines");
+  });
+});

--- a/tests/instructions/e2e.test.ts
+++ b/tests/instructions/e2e.test.ts
@@ -83,7 +83,7 @@ describe("e2e: generateInstructions with recommended config", () => {
   it("generates the correct header", async () => {
     const { content } = await result;
     expect(content).toContain("# Coding Guidelines");
-    expect(content).toContain("Regenerate with: npx generate-instructions");
+    expect(content).toContain("Regenerate with: npx llm-core-instructions");
   });
 
   it("renders no-llm-artifacts rule (present in recommended)", async () => {
@@ -146,7 +146,7 @@ describe("e2e: generateInstructions with custom config", () => {
     expect(content).toBe(`# Coding Guidelines
 
 Generated from eslint-plugin-llm-core configuration.
-Regenerate with: npx generate-instructions
+Regenerate with: npx llm-core-instructions
 
 ## All Files
 

--- a/tests/instructions/generator.test.ts
+++ b/tests/instructions/generator.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { generateMarkdown } from "../../src/instructions/generator";
+import type { ResolvedRule } from "../../src/instructions/types";
+
+const allFilesRule: ResolvedRule = {
+  name: "max-function-length",
+  instruction: "Keep functions under 50 lines — extract helpers when they grow",
+  scope: "all",
+};
+
+const typescriptRule: ResolvedRule = {
+  name: "explicit-export-types",
+  instruction:
+    "Add explicit parameter and return type annotations on all exported functions",
+  scope: "typescript-only",
+};
+
+describe("generateMarkdown", () => {
+  it("renders all-files and TypeScript-only rule sections", () => {
+    expect(generateMarkdown([allFilesRule, typescriptRule])).toBe(
+      `
+# Coding Guidelines
+
+Generated from eslint-plugin-llm-core configuration.
+Regenerate with: npx generate-instructions
+
+## All Files
+
+- Keep functions under 50 lines — extract helpers when they grow
+
+## TypeScript Files Only
+
+- Add explicit parameter and return type annotations on all exported functions
+`.trimStart(),
+    );
+  });
+
+  it("omits the TypeScript-only section when there are no TS-only rules", () => {
+    expect(generateMarkdown([allFilesRule])).toBe(
+      `
+# Coding Guidelines
+
+Generated from eslint-plugin-llm-core configuration.
+Regenerate with: npx generate-instructions
+
+## All Files
+
+- Keep functions under 50 lines — extract helpers when they grow
+`.trimStart(),
+    );
+  });
+
+  it("renders the document header even when there are no active rules", () => {
+    expect(generateMarkdown([])).toBe(
+      `
+# Coding Guidelines
+
+Generated from eslint-plugin-llm-core configuration.
+Regenerate with: npx generate-instructions
+`.trimStart(),
+    );
+  });
+});

--- a/tests/instructions/generator.test.ts
+++ b/tests/instructions/generator.test.ts
@@ -22,7 +22,7 @@ describe("generateMarkdown", () => {
 # Coding Guidelines
 
 Generated from eslint-plugin-llm-core configuration.
-Regenerate with: npx generate-instructions
+Regenerate with: npx llm-core-instructions
 
 ## All Files
 
@@ -41,7 +41,7 @@ Regenerate with: npx generate-instructions
 # Coding Guidelines
 
 Generated from eslint-plugin-llm-core configuration.
-Regenerate with: npx generate-instructions
+Regenerate with: npx llm-core-instructions
 
 ## All Files
 
@@ -56,7 +56,7 @@ Regenerate with: npx generate-instructions
 # Coding Guidelines
 
 Generated from eslint-plugin-llm-core configuration.
-Regenerate with: npx generate-instructions
+Regenerate with: npx llm-core-instructions
 `.trimStart(),
     );
   });

--- a/tests/instructions/generator.test.ts
+++ b/tests/instructions/generator.test.ts
@@ -22,7 +22,7 @@ describe("generateMarkdown", () => {
 # Coding Guidelines
 
 Generated from eslint-plugin-llm-core configuration.
-Regenerate with: npx generate-instructions
+Regenerate with: npx eslint-plugin-llm-core generate-instructions
 
 ## All Files
 
@@ -41,7 +41,7 @@ Regenerate with: npx generate-instructions
 # Coding Guidelines
 
 Generated from eslint-plugin-llm-core configuration.
-Regenerate with: npx generate-instructions
+Regenerate with: npx eslint-plugin-llm-core generate-instructions
 
 ## All Files
 
@@ -56,7 +56,7 @@ Regenerate with: npx generate-instructions
 # Coding Guidelines
 
 Generated from eslint-plugin-llm-core configuration.
-Regenerate with: npx generate-instructions
+Regenerate with: npx eslint-plugin-llm-core generate-instructions
 `.trimStart(),
     );
   });

--- a/tests/instructions/generator.test.ts
+++ b/tests/instructions/generator.test.ts
@@ -22,7 +22,7 @@ describe("generateMarkdown", () => {
 # Coding Guidelines
 
 Generated from eslint-plugin-llm-core configuration.
-Regenerate with: npx eslint-plugin-llm-core generate-instructions
+Regenerate with: npx generate-instructions
 
 ## All Files
 
@@ -41,7 +41,7 @@ Regenerate with: npx eslint-plugin-llm-core generate-instructions
 # Coding Guidelines
 
 Generated from eslint-plugin-llm-core configuration.
-Regenerate with: npx eslint-plugin-llm-core generate-instructions
+Regenerate with: npx generate-instructions
 
 ## All Files
 
@@ -56,7 +56,7 @@ Regenerate with: npx eslint-plugin-llm-core generate-instructions
 # Coding Guidelines
 
 Generated from eslint-plugin-llm-core configuration.
-Regenerate with: npx eslint-plugin-llm-core generate-instructions
+Regenerate with: npx generate-instructions
 `.trimStart(),
     );
   });

--- a/tests/instructions/interpolate.test.ts
+++ b/tests/instructions/interpolate.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { interpolateInstruction } from "../../src/instructions/config-resolver";
+
+describe("interpolateInstruction", () => {
+  it("interpolates a single configured option into the principle", () => {
+    expect(
+      interpolateInstruction(
+        {
+          principle:
+            "Keep functions under {max} lines — extract helpers when they grow",
+        },
+        { max: 40 },
+      ),
+    ).toBe("Keep functions under 40 lines — extract helpers when they grow");
+  });
+});

--- a/tests/instructions/interpolate.test.ts
+++ b/tests/instructions/interpolate.test.ts
@@ -13,4 +13,58 @@ describe("interpolateInstruction", () => {
       ),
     ).toBe("Keep functions under 40 lines — extract helpers when they grow");
   });
+
+  it("uses optionTemplate when multiple options are configured", () => {
+    expect(
+      interpolateInstruction(
+        {
+          principle:
+            "Limit function parameters to {max} — use object parameter patterns when more are needed",
+          optionTemplate:
+            "Limit function parameters to {max} (constructors: {maxConstructor}) — use object parameter patterns",
+        },
+        { max: 3, maxConstructor: 5 },
+      ),
+    ).toBe(
+      "Limit function parameters to 3 (constructors: 5) — use object parameter patterns",
+    );
+  });
+
+  it("leaves placeholders untouched when multiple options are configured without an optionTemplate", () => {
+    expect(
+      interpolateInstruction(
+        {
+          principle:
+            "Keep complexity under {max} and constructors under {maxConstructor}",
+        },
+        { max: 10, maxConstructor: 5 },
+      ),
+    ).toBe(
+      "Keep complexity under {max} and constructors under {maxConstructor}",
+    );
+  });
+
+  it("renders array options as comma-separated values", () => {
+    expect(
+      interpolateInstruction(
+        {
+          principle: "Extract named constants for all magic numbers",
+          optionTemplate:
+            "Extract named constants for magic numbers (ignore: {ignore})",
+        },
+        { ignore: [5, 10, 15] },
+      ),
+    ).toBe("Extract named constants for magic numbers (ignore: 5, 10, 15)");
+  });
+
+  it("returns the principle as-is when no options are configured", () => {
+    expect(
+      interpolateInstruction(
+        {
+          principle: "Never use type assertions to 'any'",
+        },
+        {},
+      ),
+    ).toBe("Never use type assertions to 'any'");
+  });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
       provider: "v8",
       reporter: ["text", "lcov"],
       include: ["src/**/*.ts"],
-      exclude: ["src/**/index.ts", "evals/**"],
+      exclude: ["src/**/index.ts", "src/cli/**", "evals/**"],
       thresholds: {
         statements: 93,
         branches: 85,


### PR DESCRIPTION
## Summary

Closes #120

Adds a CLI command and programmatic API that reads the project's active `eslint-plugin-llm-core` config and generates a behavioral guidelines file (`.agents/linting-rules.md`) for AI coding tools.

### What changed

- **Instruction metadata on all 24 rules** — each rule now exports a `RuleInstruction` with a `principle` (and optional `optionTemplate`) that describes its behavioral guideline with option placeholders
- **Config resolver** (`src/instructions/config-resolver.ts`) — reads ESLint flat config via `calculateConfigForFile`, resolves active llm-core rules with their configured options, derives JS-vs-TS scope using virtual file paths
- **Markdown generator** (`src/instructions/generator.ts`) — produces `## All Files` and `## TypeScript Files Only` sections from resolved rules
- **Programmatic API** — `generateInstructions()` exported from `eslint-plugin-llm-core/instructions`
- **CLI** — `npx eslint-plugin-llm-core generate-instructions` with `--config` and `--dry-run` flags
- **E2e tests** — 19 tests using real ESLint flat config fixtures against the built plugin, including exact markdown snapshot, overwrite verification, scope separation, option interpolation, off-rule exclusion, and CLI smoke tests
- **Unit tests** — 12 tests for interpolation and markdown generation with mocked ESLint
- **README** — new "Generated Instructions" section with usage docs and examples

### How to verify

```bash
npm run build
npx eslint-plugin-llm-core generate-instructions --dry-run
npm test   # 715 tests pass (696 existing + 19 new)
```

## Checklist

- [x] `tsc --noEmit` passes
- [x] `npm test` passes (715 tests)
- [x] `npm run lint` passes
- [x] `npm run build` passes
- [x] Off rules excluded from generated output
- [x] Configured option values interpolated into instruction text
- [x] TS-only rules appear in separate section (derived from config)
- [x] `warn` and `error` severity render identically
- [x] CLI `--dry-run` prints to stdout, default writes `.agents/linting-rules.md`
- [x] Overwrites existing file (verified with sentinel content)
- [x] Exact markdown snapshot assertion for custom config fixture

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI command to generate .agents/linting-rules.md (supports --config and --dry-run) and a programmatic generateInstructions API; outputs grouped, interpolated guidance for All Files vs. TypeScript-only.
* **Documentation**
  * README section documenting the CLI, API, options, and example generated markdown.
* **Tests**
  * New unit and end-to-end tests and fixtures covering resolution, interpolation, markdown output, and CLI behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->