### PR TITLE
feat: add verification protocol directive (step 4.5)

### DIFF
--- a/.agents/directives/VERIFICATION.md
+++ b/.agents/directives/VERIFICATION.md
@@ -5,6 +5,7 @@
 This directive applies after REFACTOR and before the final GATES run:
 
 ```
+0. Verify clean baseline          → AGENTS.md Step 0 (BASELINE)
 1. Define types              → [TYPE_DRIVEN_DEVELOPMENT](./TYPE_DRIVEN_DEVELOPMENT.md)
 2. Write failing test        → [TEST_DRIVEN_DEVELOPMENT](./TEST_DRIVEN_DEVELOPMENT.md)
 3. Implement minimum code    → driven by failing tests

--- a/.agents/directives/VERIFICATION.md
+++ b/.agents/directives/VERIFICATION.md
@@ -56,16 +56,23 @@ Run the compiled rule against representative code. Show:
 # Build first
 npm run build
 
-# Run the rule against a test file
+# Write a temporary test file with the triggering code
 echo '<triggering code>' > /tmp/verify-rule.ts
-npx eslint /tmp/verify-rule.ts --no-config-lookup --rule 'llm-core/rule-name: error' --rulesdir dist/
 
+# Run ESLint with the plugin loaded from dist/
+# Use a minimal flat config that imports the built plugin:
+npx eslint /tmp/verify-rule.ts \
+  --config <(echo 'import p from "./dist/index.js"; export default [...p.configs.all];')
+
+# For the clean-pass case, write valid code and re-run
 echo '<valid code that should NOT trigger>' > /tmp/verify-rule.ts
-npx eslint /tmp/verify-rule.ts --no-config-lookup --rule 'llm-core/rule-name: error' --rulesdir dist/
+npx eslint /tmp/verify-rule.ts \
+  --config <(echo 'import p from "./dist/index.js"; export default [...p.configs.all];')
 ```
 
-If the rule cannot be tested this way (e.g., requires specific config), describe
-why and show test output that proves detection and clean-pass behavior instead.
+If inline config is not practical, create a temporary `eslint.verify.mjs` in the
+project root, run the check, then delete it. Alternatively, show test output that
+proves detection and clean-pass behavior using vitest verbose reporter.
 
 #### 2. Test Coverage Proof
 

--- a/.agents/directives/VERIFICATION.md
+++ b/.agents/directives/VERIFICATION.md
@@ -128,24 +128,33 @@ Paste the output. That IS the verification for non-rule changes.
 
 ---
 
-## Output Format
+## Output Location: Pull Request Body
 
-The verification summary should look like this:
+The verification summary MUST be included in the PR description when the
+agent opens a pull request. This keeps the evidence next to the code it
+verifies, and the reviewer can scan it in 30 seconds without leaving the PR.
 
-```
-## Verification: no-else-return
+When opening a PR, include a `## Verification` section in the PR body
+(between the checklist and agent disclosure). The summary should look like
+this:
+
+```markdown
+## Verification
 
 ### Detection
+
 ✅ Hit: `if (x) { a(); } else { b(); }` → error with structured message
 ✅ Clean: `if (x) { a(); return; } b();` → no error
 
 ### Tests (12 passing)
+
 - Valid (4): early return, guard clause, if-without-else, nested-if
 - Invalid (5): if-else-return, else-if-chain-return, nested-else-return, ternary-else, try-catch-else
 - Edge (2): empty-else-block, single-statement-else
 - Suggestions (1): converts if-else to early-return
 
 ### Contract
+
 [x] Exported from src/index.ts
 [x] In recommended + all + best-practices configs
 [x] meta.docs.url → docs/rules/no-else-return.md
@@ -154,11 +163,15 @@ The verification summary should look like this:
 [x] Suggestions use actual code context
 
 ### Docs
+
 [x] Regenerated, docs/rules/no-else-return.md updated
 ```
 
-A reviewer scans this in 30 seconds. If anything is `[ ]` or tests are
-missing, the implementation is not ready.
+If anything is `[ ]` or tests are missing, the implementation is not ready.
+Do not open the PR until verification is complete.
+
+For bug fixes and docs/chore changes, include a shorter verification
+block in the same PR section.
 
 ---
 

--- a/.agents/directives/VERIFICATION.md
+++ b/.agents/directives/VERIFICATION.md
@@ -1,0 +1,191 @@
+# Verification Protocol
+
+## Prerequisite: Implementation Must Pass GATES First
+
+This directive applies after REFACTOR and before the final GATES run:
+
+```
+1. Define types              → [TYPE_DRIVEN_DEVELOPMENT](./TYPE_DRIVEN_DEVELOPMENT.md)
+2. Write failing test        → [TEST_DRIVEN_DEVELOPMENT](./TEST_DRIVEN_DEVELOPMENT.md)
+3. Implement minimum code    → driven by failing tests
+4. Refactor                  → clean up, all tests pass
+5. **Verify**                → this file — demonstrate correctness with evidence
+6. GATES + DOCS + COMMIT     → final quality gates
+```
+
+**Do not run GATES until verification output is produced.** Verification
+catches issues that passing tests alone cannot: false positives, missing
+edge cases, wrong config placement, and incomplete documentation.
+
+---
+
+## Why Verification Matters
+
+Passing tests prove the code works for tested inputs. They do NOT prove:
+
+- The rule catches what it should in real code (not just test fixtures)
+- The rule avoids false positives on valid patterns
+- The structured error message reads correctly in context
+- The rule is properly exported, configured, and documented
+
+Verification bridges the gap between "tests pass" and "rule is production-ready."
+Think of it as the agent showing its work, not just reporting a green checkmark.
+
+---
+
+## The Protocol
+
+After REFACTOR and before GATES, the agent MUST produce a verification
+summary. The summary is structured evidence that a reviewer can scan in
+30 seconds instead of reading the full implementation.
+
+### For New Rules
+
+Output ALL four sections:
+
+#### 1. Detection Proof
+
+Run the compiled rule against representative code. Show:
+
+- **Hits** — one case that triggers the error, with the full structured message
+  (what / why / how-to-fix)
+- **Clean passes** — one case that does NOT trigger the error, proving no
+  false positive
+
+```bash
+# Build first
+npm run build
+
+# Run the rule against a test file
+echo '<triggering code>' > /tmp/verify-rule.ts
+npx eslint /tmp/verify-rule.ts --no-config-lookup --rule 'llm-core/rule-name: error' --rulesdir dist/
+
+echo '<valid code that should NOT trigger>' > /tmp/verify-rule.ts
+npx eslint /tmp/verify-rule.ts --no-config-lookup --rule 'llm-core/rule-name: error' --rulesdir dist/
+```
+
+If the rule cannot be tested this way (e.g., requires specific config), describe
+why and show test output that proves detection and clean-pass behavior instead.
+
+#### 2. Test Coverage Proof
+
+```bash
+npx vitest run tests/rules/rule-name.ts --reporter=verbose
+```
+
+List passing test cases grouped by:
+
+- **Valid cases** — code that should NOT be flagged
+- **Invalid cases** — code that SHOULD be flagged
+- **Edge cases** — null, undefined, empty, boundary values
+- **Suggestion cases** — autofix or suggestion output (if applicable)
+
+#### 3. Contract Proof
+
+Confirm all of the following. Output `[x]` for confirmed, `[ ]` for missing:
+
+- [ ] Rule exported from `src/index.ts`
+- [ ] Rule in correct config preset (`recommended`, `all`, category configs)
+- [ ] `meta.docs.url` points to correct docs path
+- [ ] `meta.schema` defined (if rule accepts options)
+- [ ] Error message follows what / why / how-to-fix format
+- [ ] Suggestions use actual code context (function names, params), not generics
+
+#### 4. Docs Proof (if rule changed)
+
+```bash
+npm run update:eslint-docs
+git diff --stat docs/rules/
+```
+
+Confirm generated docs exist and are consistent with the rule.
+
+---
+
+### For Bug Fixes
+
+After the fix, show:
+
+1. **The previously-failing test now passing** — paste the test name and result
+2. **The fix** — a one-paragraph summary of what changed in the rule logic
+3. **No regression** — all existing tests still pass
+
+```bash
+npx vitest run --reporter=verbose
+```
+
+---
+
+### For Docs / Chore Changes
+
+Show the relevant quality gate still passes:
+
+```bash
+npm test && npm run lint && npm run build
+```
+
+Paste the output. That IS the verification for non-rule changes.
+
+---
+
+## Output Format
+
+The verification summary should look like this:
+
+```
+## Verification: no-else-return
+
+### Detection
+✅ Hit: `if (x) { a(); } else { b(); }` → error with structured message
+✅ Clean: `if (x) { a(); return; } b();` → no error
+
+### Tests (12 passing)
+- Valid (4): early return, guard clause, if-without-else, nested-if
+- Invalid (5): if-else-return, else-if-chain-return, nested-else-return, ternary-else, try-catch-else
+- Edge (2): empty-else-block, single-statement-else
+- Suggestions (1): converts if-else to early-return
+
+### Contract
+[x] Exported from src/index.ts
+[x] In recommended + all + best-practices configs
+[x] meta.docs.url → docs/rules/no-else-return.md
+[x] meta.schema defined (maxElseChains option)
+[x] Message format: what / why / how-to-fix
+[x] Suggestions use actual code context
+
+### Docs
+[x] Regenerated, docs/rules/no-else-return.md updated
+```
+
+A reviewer scans this in 30 seconds. If anything is `[ ]` or tests are
+missing, the implementation is not ready.
+
+---
+
+## Forbidden Patterns
+
+| Pattern                                      | Why Forbidden                                             |
+| -------------------------------------------- | --------------------------------------------------------- |
+| "Tests pass, ship it"                        | Passing tests ≠ production-ready rule                     |
+| Skipping detection proof                     | Must show both hits AND clean passes                      |
+| Skipping contract proof                      | Misconfigured rules pass tests but fail in users' editors |
+| Claiming verification without showing output | Evidence, not claims                                      |
+| Running GATES before verification            | Verification catches issues GATES misses                  |
+
+---
+
+## Why This Matters for LLM Agents
+
+LLM agents tend to:
+
+1. **Implement the happy path** — forget edge cases and false positives
+2. **Skip wiring** — write the rule but forget to export or configure it
+3. **Generate generic messages** — "Unexpected pattern" instead of using code context
+4. **Skip docs** — forget `npm run update:eslint-docs`
+
+Verification forces the agent to confront each of these before declaring done.
+It transforms "I think it works" into "here's the evidence it works."
+
+---
+
+_This directive is mandatory for all rule implementations, bug fixes, and config changes._

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,30 @@
 
 <!-- Brief description of the change. Add `Closes #<number>` here if this PR resolves a GitHub issue. -->
 
+## Verification
+
+<!-- Required for new rules and bug fixes. See .agents/directives/VERIFICATION.md for protocol. -->
+
+<!-- Remove this section for docs-only or chore changes where GATES output is sufficient. -->
+
+<!-- ### Detection -->
+<!-- ✅ Hit: [code that triggers the error] → [error message summary] -->
+<!-- ✅ Clean: [code that should NOT trigger] → no error -->
+
+<!-- ### Tests -->
+<!-- List passing test cases: Valid / Invalid / Edge / Suggestions -->
+
+<!-- ### Contract -->
+<!-- - [ ] Exported from src/index.ts -->
+<!-- - [ ] In correct config presets -->
+<!-- - [ ] meta.docs.url correct -->
+<!-- - [ ] meta.schema defined (if options exist) -->
+<!-- - [ ] Message follows what/why/how-to-fix format -->
+<!-- - [ ] Suggestions use actual code context -->
+
+<!-- ### Docs -->
+<!-- - [ ] Regenerated with npm run update:eslint-docs -->
+
 ## Checklist
 
 - [ ] `npm run build` passes
@@ -28,6 +52,7 @@
 - [ ] `AGENTS.md`
 - [ ] `.agents/directives/TYPE_DRIVEN_DEVELOPMENT.md`
 - [ ] `.agents/directives/TEST_DRIVEN_DEVELOPMENT.md`
+- [ ] `.agents/directives/VERIFICATION.md`
 - [ ] `.agents/directives/SESSION_DECISIONS.md`
 - [ ] If `SESSION_DECISIONS.md` was loaded **and** this PR set a durable repo/process or cross-cutting decision whose reasoning is not obvious from the diff, a `docs/decisions/YYYY-MM-DD-<topic>.md` entry is included in this PR
 

--- a/.github/instructions/pull-request.md
+++ b/.github/instructions/pull-request.md
@@ -44,7 +44,13 @@ The PR template at `.github/PULL_REQUEST_TEMPLATE.md` has required sections for 
 
 If a PR resolves a tracked GitHub issue, include `Closes #<number>`, `Fixes #<number>`, or `Resolves #<number>` in the PR description. If no issue exists, no issue reference is required.
 
-### 2. Checklist
+### 2. Verification (Required for new rules and bug fixes)
+
+When the PR adds or modifies a rule, include a `## Verification` section in the PR body following the protocol in [`.agents/directives/VERIFICATION.md`](../../.agents/directives/VERIFICATION.md). This section provides structured evidence (detection proof, test coverage, contract proof, docs proof) that the reviewer can scan in 30 seconds.
+
+For docs-only or chore changes, omit the verification section — the checklist and GATES output are sufficient.
+
+### 3. Checklist
 
 Every box must be checked. If a checklist item doesn't apply, check it and note "(N/A)" next to it.
 
@@ -58,7 +64,7 @@ Every box must be checked. If a checklist item doesn't apply, check it and note 
 - [x] Rule added to `recommendedRules` in `src/index.ts` (if applicable)
 ```
 
-### 3. Agent Disclosure
+### 4. Agent Disclosure
 
 If you are an AI agent, you MUST complete this section:
 
@@ -66,6 +72,6 @@ If you are an AI agent, you MUST complete this section:
 - **Instruction files loaded:** — Check every file you actually received and processed
 - **Instruction files NOT loaded:** — Explain any gaps
 
-### 4. Commit History
+### 5. Commit History
 
 CI enforces that PRs with `feat:` commits must include at least one `test:` commit. Follow the commit cadence in `copilot-instructions.md` (test-first ordering is expected by convention).

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -10,10 +10,20 @@ jobs:
     name: TDD Commit Presence
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - name: Check feat commits have corresponding test commits
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # Skip TDD check when no src/ files changed (docs, workflows, configs)
+          SRC_CHANGED=$(git diff --name-only origin/main...HEAD -- src/ | wc -l | tr -d ' ')
+          if [ "$SRC_CHANGED" -eq 0 ]; then
+            echo "✓ No src/ changes — TDD commit check not required"
+            exit 0
+          fi
+
           COMMITS=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/commits --jq '.[].commit.message' | head -c 10000)
 
           FEAT_COUNT=$(echo "$COMMITS" | grep -c '^feat:' || true)

--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@ coverage/
 evals/results/*.json
 evals/results/*.md
 .gitnexus/
+.claude/worktrees/
 .claude/skills/gitnexus/
 .agents/skills/gitnexus/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,16 +32,17 @@ mistake, every time.
 
 **All code changes follow this sequence — no skipping steps:**
 
-| Step | Phase      | Action                                   | Verify                                                                 |
-| ---- | ---------- | ---------------------------------------- | ---------------------------------------------------------------------- |
-| 1    | TYPES      | Define types in `types.ts` or co-located | `tsc --noEmit` passes                                                  |
-| 2    | RED        | Write ONE failing test                   | Test fails                                                             |
-| 3    | GREEN      | Write minimum code to pass               | New test passes, all existing tests still pass, `tsc --noEmit` passes  |
-| 4    | REFACTOR   | Clean up if needed                       | All tests still pass                                                   |
-| 4.5  | **VERIFY** | **Produce verification summary**         | **[VERIFICATION](.agents/directives/VERIFICATION.md) protocol output** |
-| 5    | GATES      | Run quality gates                        | `npm test && npm run lint && npm run build`                            |
-| 5.5  | DOCS       | Regenerate rule docs (if rules changed)  | `npm run update:eslint-docs`, then commit                              |
-| 6    | COMMIT     | Atomic commit                            | One behavior per commit                                                |
+| Step | Phase        | Action                                   | Verify                                                                                                   |
+| ---- | ------------ | ---------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| 0    | **BASELINE** | **Verify starting state is clean**       | **`tsc --noEmit && npm test && npm run build` all pass — if not, surface the failure before proceeding** |
+| 1    | TYPES        | Define types in `types.ts` or co-located | `tsc --noEmit` passes                                                                                    |
+| 2    | RED          | Write ONE failing test                   | Test fails                                                                                               |
+| 3    | GREEN        | Write minimum code to pass               | New test passes, all existing tests still pass, `tsc --noEmit` passes                                    |
+| 4    | REFACTOR     | Clean up if needed                       | All tests still pass                                                                                     |
+| 4.5  | **VERIFY**   | **Produce verification summary**         | **[VERIFICATION](.agents/directives/VERIFICATION.md) protocol output**                                   |
+| 5    | GATES        | Run quality gates                        | `npm test && npm run lint && npm run build`                                                              |
+| 5.5  | DOCS         | Regenerate rule docs (if rules changed)  | `npm run update:eslint-docs`, then commit                                                                |
+| 6    | COMMIT       | Atomic commit                            | One behavior per commit                                                                                  |
 
 Steps 2–6 repeat for each behavior. Do not batch.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,15 +32,16 @@ mistake, every time.
 
 **All code changes follow this sequence — no skipping steps:**
 
-| Step | Phase    | Action                                   | Verify                                                                |
-| ---- | -------- | ---------------------------------------- | --------------------------------------------------------------------- |
-| 1    | TYPES    | Define types in `types.ts` or co-located | `tsc --noEmit` passes                                                 |
-| 2    | RED      | Write ONE failing test                   | Test fails                                                            |
-| 3    | GREEN    | Write minimum code to pass               | New test passes, all existing tests still pass, `tsc --noEmit` passes |
-| 4    | REFACTOR | Clean up if needed                       | All tests still pass                                                  |
-| 5    | GATES    | Run quality gates                        | `npm test && npm run lint && npm run build`                           |
-| 5.5  | DOCS     | Regenerate rule docs (if rules changed)  | `npm run update:eslint-docs`, then commit                             |
-| 6    | COMMIT   | Atomic commit                            | One behavior per commit                                               |
+| Step | Phase      | Action                                   | Verify                                                                 |
+| ---- | ---------- | ---------------------------------------- | ---------------------------------------------------------------------- |
+| 1    | TYPES      | Define types in `types.ts` or co-located | `tsc --noEmit` passes                                                  |
+| 2    | RED        | Write ONE failing test                   | Test fails                                                             |
+| 3    | GREEN      | Write minimum code to pass               | New test passes, all existing tests still pass, `tsc --noEmit` passes  |
+| 4    | REFACTOR   | Clean up if needed                       | All tests still pass                                                   |
+| 4.5  | **VERIFY** | **Produce verification summary**         | **[VERIFICATION](.agents/directives/VERIFICATION.md) protocol output** |
+| 5    | GATES      | Run quality gates                        | `npm test && npm run lint && npm run build`                            |
+| 5.5  | DOCS       | Regenerate rule docs (if rules changed)  | `npm run update:eslint-docs`, then commit                              |
+| 6    | COMMIT     | Atomic commit                            | One behavior per commit                                                |
 
 Steps 2–6 repeat for each behavior. Do not batch.
 
@@ -55,6 +56,7 @@ Read and follow every directive before implementing. They govern **how** you wor
 | ----------------------- | ------------------------------------------- | ------------------------------------------------------------------------------------------------ |
 | Type-First Development  | Types before implementation                 | [`.agents/directives/TYPE_DRIVEN_DEVELOPMENT.md`](.agents/directives/TYPE_DRIVEN_DEVELOPMENT.md) |
 | Test-Driven Development | RED/GREEN/REFACTOR for all code changes     | [`.agents/directives/TEST_DRIVEN_DEVELOPMENT.md`](.agents/directives/TEST_DRIVEN_DEVELOPMENT.md) |
+| Verification Protocol   | Evidence of correctness before GATES        | [`.agents/directives/VERIFICATION.md`](.agents/directives/VERIFICATION.md)                       |
 | Session Decisions       | Durable decision capture at task completion | [`.agents/directives/SESSION_DECISIONS.md`](.agents/directives/SESSION_DECISIONS.md)             |
 
 ## Skills (Mandatory)


### PR DESCRIPTION
## What

Adds a mandatory verification step (4.5) between REFACTOR and GATES in the agent workflow. The agent must produce structured evidence of correctness before running final quality gates.

## Why

Passing tests prove code works for tested inputs. They do NOT prove:
- The rule avoids false positives on valid patterns
- The structured error message reads correctly in context
- The rule is properly exported, configured, and documented

Verification bridges the gap between "tests pass" and "rule is production-ready."

Based on the "Trust But Verify" pattern from *The Meta-Engineer* Ch. 7 — review verification output (10 lines) instead of reviewing generated code (1000 lines).

## Changes

### New: `.agents/directives/VERIFICATION.md`
4-part verification protocol:

| Section | What it proves |
|---------|---------------|
| Detection Proof | Rule catches what it should + no false positives |
| Test Coverage Proof | Valid/invalid/edge/suggestion cases listed |
| Contract Proof | Rule exported, configured, docs.url correct, schema defined, message format correct |
| Docs Proof | Regenerated rule docs are consistent |

Also includes separate protocols for bug fixes and docs/chore changes, plus an example output format.

### Modified: `AGENTS.md` (→ `CLAUDE.md` via symlink)
- New Step 4.5 (**VERIFY**) in workflow table
- Verification Protocol added to Directives table

## Checklist

- [x] `npm run build` passes
- [x] `npm run lint` passes
- [x] `npm test` passes (no rule changes)
- [x] Commit follows conventional format