### PR TITLE
feat: inject linting-rules.md references into agent instruction files

### DIFF
--- a/.changeset/inject-references.md
+++ b/.changeset/inject-references.md
@@ -1,0 +1,9 @@
+---
+"eslint-plugin-llm-core": minor
+---
+
+Add automatic injection of linting-rules.md references into agent instruction files
+
+After generating `.agents/linting-rules.md`, the CLI now appends a reference block
+into any existing instruction files (AGENTS.md, CLAUDE.md, .github/copilot-instructions.md).
+Re-running replaces the block in-place — no duplicates. Use `--no-inject` to skip injection.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,9 +4,13 @@
 
 ## Verification
 
-<!-- Required for new rules and bug fixes. See .agents/directives/VERIFICATION.md for protocol. -->
+<!-- Required for all code changes. See .agents/directives/VERIFICATION.md for protocol. -->
 
-<!-- Remove this section for docs-only or chore changes where GATES output is sufficient. -->
+<!-- For new rules and bug fixes: include Detection, Tests, Contract, and Docs proof. -->
+
+<!-- For other code changes (CLI features, refactors, config): demonstrate correctness with evidence. -->
+
+<!-- Docs-only changes (no src/ modifications) may omit this section. -->
 
 <!-- ### Detection -->
 <!-- ✅ Hit: [code that triggers the error] → [error message summary] -->

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,8 +1,16 @@
 # Copilot Instructions for eslint-plugin-llm-core
 
+## What This Project Is
+
+A framework-agnostic ESLint plugin (TypeScript, strict mode) that helps LLM agents self-correct. Rules use `@typescript-eslint/utils` and the visitor pattern over AST nodes.
+
 ## STOP — Read Before Writing Any Code
 
 You MUST commit after every step. Do NOT batch work into a single commit.
+
+### BASELINE (before starting work)
+
+Run `tsc --noEmit && npm test && npm run build`. If any fails, stop and report before proceeding.
 
 ### The Commit Cadence (non-negotiable)
 
@@ -34,9 +42,9 @@ feat: no-foo handles arrow functions
 
 If you produce a single commit like `feat: add no-foo rule` with everything inside, the PR will fail CI.
 
-## What This Project Is
+### VERIFY (before GATES, after implementation)
 
-A framework-agnostic ESLint plugin (TypeScript, strict mode) that helps LLM agents self-correct. Rules use `@typescript-eslint/utils` and the visitor pattern over AST nodes.
+Before running `npm test && npm run lint && npm run build`, produce a verification summary following `.agents/directives/VERIFICATION.md`.
 
 ## Commands
 

--- a/.github/instructions/pull-request.md
+++ b/.github/instructions/pull-request.md
@@ -44,11 +44,11 @@ The PR template at `.github/PULL_REQUEST_TEMPLATE.md` has required sections for 
 
 If a PR resolves a tracked GitHub issue, include `Closes #<number>`, `Fixes #<number>`, or `Resolves #<number>` in the PR description. If no issue exists, no issue reference is required.
 
-### 2. Verification (Required for new rules and bug fixes)
+### 2. Verification (Required for all code changes)
 
-When the PR adds or modifies a rule, include a `## Verification` section in the PR body following the protocol in [`.agents/directives/VERIFICATION.md`](../../.agents/directives/VERIFICATION.md). This section provides structured evidence (detection proof, test coverage, contract proof, docs proof) that the reviewer can scan in 30 seconds.
+Include a `## Verification` section in the PR body following the protocol in `.agents/directives/VERIFICATION.md`. For new rules and bug fixes, this means detection proof, test coverage, contract proof, and docs proof. For other code changes (CLI features, refactors, config), demonstrate correctness with evidence — test output, manual verification, or behavioral proof.
 
-For docs-only or chore changes, omit the verification section — the checklist and GATES output are sufficient.
+Docs-only changes (no `src/` modifications) may omit the verification section.
 
 ### 3. Checklist
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ mistake, every time.
 | 2    | RED          | Write ONE failing test                   | Test fails                                                                                               |
 | 3    | GREEN        | Write minimum code to pass               | New test passes, all existing tests still pass, `tsc --noEmit` passes                                    |
 | 4    | REFACTOR     | Clean up if needed                       | All tests still pass                                                                                     |
-| 4.5  | **VERIFY**   | **Produce verification summary**         | **[VERIFICATION](.agents/directives/VERIFICATION.md) protocol output**                                   |
+| 4.5  | **VERIFY**   | **Produce verification summary**         | **See [`.agents/directives/VERIFICATION.md`](.agents/directives/VERIFICATION.md) for protocol**          |
 | 5    | GATES        | Run quality gates                        | `npm test && npm run lint && npm run build`                                                              |
 | 5.5  | DOCS         | Regenerate rule docs (if rules changed)  | `npm run update:eslint-docs`, then commit                                                                |
 | 6    | COMMIT       | Atomic commit                            | One behavior per commit                                                                                  |

--- a/README.md
+++ b/README.md
@@ -231,14 +231,15 @@ Unlike static instruction files, generated instructions are:
 npx llm-core-instructions
 ```
 
-This reads your `eslint.config.*`, resolves active `llm-core` rules, and generates `.agents/linting-rules.md` with behavioral guidelines for AI coding tools.
+This reads your `eslint.config.*`, resolves active `llm-core` rules, and generates `.agents/linting-rules.md` with behavioral guidelines for AI coding tools. It also appends a reference to the generated file into any existing agent instruction files (`AGENTS.md`, `CLAUDE.md`, `.github/copilot-instructions.md`) so agent tools discover it automatically. Re-running replaces the reference in-place — no duplicates.
 
 **Flags:**
 
-| Flag              | Description                                             |
-| ----------------- | ------------------------------------------------------- |
-| `--config <path>` | Specify ESLint config file path (default: auto-detect)  |
-| `--dry-run`       | Print generated content to stdout without writing files |
+| Flag              | Description                                                                              |
+| ----------------- | ---------------------------------------------------------------------------------------- |
+| `--config <path>` | Specify ESLint config file path (default: auto-detect)                                   |
+| `--dry-run`       | Print generated content to stdout without writing files                                  |
+| `--no-inject`     | Generate `.agents/linting-rules.md` only, skip appending references to instruction files |
 
 **Example output:**
 
@@ -276,32 +277,6 @@ result.allFilesRules; // Rules applying to all files
 result.typescriptRules; // TypeScript-only rules
 ```
 
-## Agent Skills
-
-Beyond ESLint rules, this plugin ships **agent skills** — markdown instruction files that LLM agents can load when performing specific tasks. Skills complement the lint rules by catching patterns that require judgment rather than pattern matching.
-
-### Available Skills
-
-| Skill                                    | Description                                                                                                                    |
-| ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| [test-reviewer](skills/test-reviewer.md) | Detects tests that duplicate production logic, use shallow assertions, skip edge cases, or assert on mocks instead of behavior |
-
-### Usage
-
-Copy the skill file into your agent's skill directory:
-
-```bash
-# Claude Code
-cp node_modules/eslint-plugin-llm-core/skills/test-reviewer.md .claude/skills/
-
-# Cursor
-cp node_modules/eslint-plugin-llm-core/skills/test-reviewer.md .cursor/skills/
-
-# Or wherever your agent tool looks for skills
-```
-
-The skill is a standalone markdown file with no dependencies. Adapt it to your project's testing conventions as needed.
-
 ## Contributing
 
 ```bash
@@ -311,7 +286,7 @@ npm run test
 npm run lint
 ```
 
-See [CLAUDE.md](CLAUDE.md) for architecture details and how to add new rules.
+See [AGENTS.md](AGENTS.md) for architecture details and how to add new rules.
 
 ## Roadmap
 

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ This reads your `eslint.config.*`, resolves active `llm-core` rules, and generat
 | Flag              | Description                                                                              |
 | ----------------- | ---------------------------------------------------------------------------------------- |
 | `--config <path>` | Specify ESLint config file path (default: auto-detect)                                   |
-| `--dry-run`       | Print generated content to stdout without writing files                                  |
+| `--dry-run`       | Print generated content to stdout; skips file generation and injection                   |
 | `--no-inject`     | Generate `.agents/linting-rules.md` only, skip appending references to instruction files |
 
 **Example output:**
@@ -276,6 +276,32 @@ result.activeRules; // Resolved rules with options and derived scope
 result.allFilesRules; // Rules applying to all files
 result.typescriptRules; // TypeScript-only rules
 ```
+
+## Agent Skills
+
+Beyond ESLint rules, this plugin ships **agent skills** — markdown instruction files that LLM agents can load when performing specific tasks. Skills complement the lint rules by catching patterns that require judgment rather than pattern matching.
+
+### Available Skills
+
+| Skill                                    | Description                                                                                                                    |
+| ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| [test-reviewer](skills/test-reviewer.md) | Detects tests that duplicate production logic, use shallow assertions, skip edge cases, or assert on mocks instead of behavior |
+
+### Usage
+
+Copy the skill file into your agent's skill directory:
+
+```bash
+# Claude Code
+cp node_modules/eslint-plugin-llm-core/skills/test-reviewer.md .claude/skills/
+
+# Cursor
+cp node_modules/eslint-plugin-llm-core/skills/test-reviewer.md .cursor/skills/
+
+# Or wherever your agent tool looks for skills
+```
+
+The skill is a standalone markdown file with no dependencies. Adapt it to your project's testing conventions as needed.
 
 ## Contributing
 

--- a/src/cli/generate-instructions.ts
+++ b/src/cli/generate-instructions.ts
@@ -2,17 +2,21 @@
 import fs from "fs";
 import path from "path";
 import { generateInstructions } from "../generate-instructions";
+import { injectReferences } from "./inject-references";
 
 async function main(): Promise<void> {
   const args = process.argv.slice(2);
   let configPath: string | undefined;
   let dryRun = false;
+  let noInject = false;
 
   for (let i = 0; i < args.length; i++) {
     if (args[i] === "--config" && args[i + 1]) {
       configPath = args[++i];
     } else if (args[i] === "--dry-run") {
       dryRun = true;
+    } else if (args[i] === "--no-inject") {
+      noInject = true;
     }
   }
 
@@ -31,6 +35,13 @@ async function main(): Promise<void> {
   const outputPath = path.join(agentsDir, "linting-rules.md");
   fs.writeFileSync(outputPath, result.content, "utf-8");
   console.log(`Generated ${outputPath}`);
+
+  if (!noInject) {
+    const modified = injectReferences(process.cwd());
+    for (const file of modified) {
+      console.log(`Injected reference into ${file}`);
+    }
+  }
 }
 
 main().catch((error: unknown) => {

--- a/src/cli/inject-references.ts
+++ b/src/cli/inject-references.ts
@@ -19,3 +19,7 @@ export function findInstructionFiles(cwd: string): string[] {
     fs.existsSync(path.join(cwd, filePath)),
   );
 }
+
+export function computeRelativePath(targetFile: string): string {
+  return path.relative(path.dirname(targetFile), lintingRulesPath);
+}

--- a/src/cli/inject-references.ts
+++ b/src/cli/inject-references.ts
@@ -21,7 +21,10 @@ export function findInstructionFiles(cwd: string): string[] {
 }
 
 export function computeRelativePath(targetFile: string): string {
-  return path.relative(path.dirname(targetFile), lintingRulesPath);
+  return path
+    .relative(path.dirname(targetFile), lintingRulesPath)
+    .split(path.sep)
+    .join("/");
 }
 
 export function buildInjectionBlock(relativePath: string): string {

--- a/src/cli/inject-references.ts
+++ b/src/cli/inject-references.ts
@@ -67,8 +67,10 @@ export function injectReferences(cwd: string): string[] {
     try {
       const content = fs.readFileSync(fullPath, "utf-8");
       const updated = replaceOrAppendBlock(content, block);
-      fs.writeFileSync(fullPath, updated, "utf-8");
-      modified.push(target);
+      if (updated !== content) {
+        fs.writeFileSync(fullPath, updated, "utf-8");
+        modified.push(target);
+      }
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
       process.stderr.write(

--- a/src/cli/inject-references.ts
+++ b/src/cli/inject-references.ts
@@ -27,3 +27,52 @@ export function computeRelativePath(targetFile: string): string {
 export function buildInjectionBlock(relativePath: string): string {
   return `${injectionBlockStart}\nSee [\`.agents/linting-rules.md\`](${relativePath}) for coding guidelines derived from your ESLint config.\nRegenerate with: \`npx llm-core-instructions\`\n${injectionBlockEnd}`;
 }
+
+/**
+ * Replaces an existing injection block in `content`, or appends if none exists.
+ * Preserves all surrounding content unchanged.
+ */
+export function replaceOrAppendBlock(content: string, block: string): string {
+  const startIdx = content.indexOf(injectionBlockStart);
+  const endIdx = content.indexOf(injectionBlockEnd);
+
+  if (startIdx !== -1 && endIdx !== -1 && endIdx > startIdx) {
+    const cutEnd = endIdx + injectionBlockEnd.length;
+    return content.slice(0, startIdx) + block + content.slice(cutEnd);
+  }
+
+  const trimmed = content.endsWith("\n") ? content : content + "\n";
+  return trimmed + block + "\n";
+}
+
+/**
+ * Orchestrates injection: finds existing instruction files at `cwd`,
+ * builds blocks with correct relative paths, and writes changes.
+ * Returns the list of modified file paths.
+ *
+ * If a file is not writable, logs a warning to stderr and continues.
+ */
+export function injectReferences(cwd: string): string[] {
+  const files = findInstructionFiles(cwd);
+  const modified: string[] = [];
+
+  for (const target of files) {
+    const fullPath = path.join(cwd, target);
+    const relativePath = computeRelativePath(target);
+    const block = buildInjectionBlock(relativePath);
+
+    try {
+      const content = fs.readFileSync(fullPath, "utf-8");
+      const updated = replaceOrAppendBlock(content, block);
+      fs.writeFileSync(fullPath, updated, "utf-8");
+      modified.push(target);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      process.stderr.write(
+        `Warning: could not inject reference into ${target}: ${message}\n`,
+      );
+    }
+  }
+
+  return modified;
+}

--- a/src/cli/inject-references.ts
+++ b/src/cli/inject-references.ts
@@ -1,0 +1,21 @@
+import path from "path";
+import fs from "fs";
+
+export const instructionFilePaths = [
+  "AGENTS.md",
+  "CLAUDE.md",
+  ".github/copilot-instructions.md",
+] as const;
+
+export type InstructionFilePath = (typeof instructionFilePaths)[number];
+
+export const injectionBlockStart = "<!-- llm-core-instructions:start -->";
+export const injectionBlockEnd = "<!-- llm-core-instructions:end -->";
+
+export const lintingRulesPath = path.join(".agents", "linting-rules.md");
+
+export function findInstructionFiles(cwd: string): string[] {
+  return instructionFilePaths.filter((filePath) =>
+    fs.existsSync(path.join(cwd, filePath)),
+  );
+}

--- a/src/cli/inject-references.ts
+++ b/src/cli/inject-references.ts
@@ -23,3 +23,7 @@ export function findInstructionFiles(cwd: string): string[] {
 export function computeRelativePath(targetFile: string): string {
   return path.relative(path.dirname(targetFile), lintingRulesPath);
 }
+
+export function buildInjectionBlock(relativePath: string): string {
+  return `${injectionBlockStart}\nSee [\`.agents/linting-rules.md\`](${relativePath}) for coding guidelines derived from your ESLint config.\nRegenerate with: \`npx llm-core-instructions\`\n${injectionBlockEnd}`;
+}

--- a/tests/cli/inject-references.test.ts
+++ b/tests/cli/inject-references.test.ts
@@ -1,11 +1,23 @@
 import fs from "fs";
 import os from "os";
 import path from "path";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 import {
   buildInjectionBlock,
   computeRelativePath,
   findInstructionFiles,
+  injectReferences,
+  injectionBlockEnd,
+  injectionBlockStart,
+  replaceOrAppendBlock,
 } from "../../src/cli/inject-references";
 
 describe("inject-references", () => {
@@ -48,5 +60,150 @@ describe("inject-references", () => {
 See [\`.agents/linting-rules.md\`](../.agents/linting-rules.md) for coding guidelines derived from your ESLint config.
 Regenerate with: \`npx llm-core-instructions\`
 <!-- llm-core-instructions:end -->`);
+  });
+
+  it("replaceOrAppendBlock replaces an existing block in place", () => {
+    const original = `# Title
+
+${injectionBlockStart}
+Old block
+${injectionBlockEnd}
+
+Existing content
+`;
+    const replacement = buildInjectionBlock(".agents/linting-rules.md");
+
+    expect(replaceOrAppendBlock(original, replacement)).toBe(`# Title
+
+${replacement}
+
+Existing content
+`);
+  });
+
+  it("replaceOrAppendBlock appends when no existing block is present", () => {
+    const content = "# Existing Doc\n\nSome content\n";
+    const block = buildInjectionBlock(".agents/linting-rules.md");
+
+    const result = replaceOrAppendBlock(content, block);
+    expect(result).toContain(injectionBlockStart);
+    expect(result).toContain(injectionBlockEnd);
+    expect(result).toContain("# Existing Doc");
+    expect(result).toContain("Some content");
+    expect(result.indexOf("# Existing Doc")).toBeLessThan(
+      result.indexOf(injectionBlockStart),
+    );
+  });
+
+  it("replaceOrAppendBlock is idempotent — re-running produces identical output", () => {
+    const content = "# Doc\n\nHello\n";
+    const block = buildInjectionBlock(".agents/linting-rules.md");
+    const first = replaceOrAppendBlock(content, block);
+    const second = replaceOrAppendBlock(first, block);
+    expect(second).toBe(first);
+  });
+
+  it("findInstructionFiles returns empty array when no instruction files exist", () => {
+    const emptyDir = fs.mkdtempSync(path.join(os.tmpdir(), "llm-core-empty-"));
+    try {
+      expect(findInstructionFiles(emptyDir)).toEqual([]);
+    } finally {
+      fs.rmSync(emptyDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("injectReferences integration", () => {
+  let tmpDir = "";
+
+  beforeAll(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "llm-core-integ-"));
+  });
+
+  afterAll(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("injects into all detected files and preserves surrounding content", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "AGENTS.md"),
+      "# Before\n\nSome agents content\n",
+      "utf-8",
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, "CLAUDE.md"),
+      "# Claude\n\nClaude content\n",
+      "utf-8",
+    );
+    fs.mkdirSync(path.join(tmpDir, ".github"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, ".github", "copilot-instructions.md"),
+      "# Copilot\n\nCopilot content\n",
+      "utf-8",
+    );
+
+    const modified = injectReferences(tmpDir);
+
+    expect(modified).toEqual([
+      "AGENTS.md",
+      "CLAUDE.md",
+      ".github/copilot-instructions.md",
+    ]);
+
+    const agents = fs.readFileSync(path.join(tmpDir, "AGENTS.md"), "utf-8");
+    expect(agents).toContain("# Before");
+    expect(agents).toContain("Some agents content");
+    expect(agents).toContain(injectionBlockStart);
+    expect(agents).toContain("(.agents/linting-rules.md)");
+
+    const copilot = fs.readFileSync(
+      path.join(tmpDir, ".github", "copilot-instructions.md"),
+      "utf-8",
+    );
+    expect(copilot).toContain("(../.agents/linting-rules.md)");
+  });
+
+  it("skips missing files without error", () => {
+    const singleDir = fs.mkdtempSync(path.join(os.tmpdir(), "llm-core-skip-"));
+    try {
+      fs.writeFileSync(
+        path.join(singleDir, "CLAUDE.md"),
+        "# Only Claude\n",
+        "utf-8",
+      );
+
+      const modified = injectReferences(singleDir);
+      expect(modified).toEqual(["CLAUDE.md"]);
+    } finally {
+      fs.rmSync(singleDir, { recursive: true, force: true });
+    }
+  });
+
+  it("logs warning to stderr for unwritable files without crashing", () => {
+    const warnDir = fs.mkdtempSync(path.join(os.tmpdir(), "llm-core-warn-"));
+    try {
+      const filePath = path.join(warnDir, "AGENTS.md");
+      fs.writeFileSync(filePath, "# Agents\n", "utf-8");
+      fs.chmodSync(filePath, 0o444);
+
+      const stderrSpy = vi
+        .spyOn(process.stderr, "write")
+        .mockImplementation(() => true);
+
+      const modified = injectReferences(warnDir);
+
+      expect(stderrSpy).toHaveBeenCalled();
+      expect(stderrSpy.mock.calls[0][0]).toContain(
+        "Warning: could not inject reference into AGENTS.md",
+      );
+      expect(modified).toEqual([]);
+    } finally {
+      fs.chmodSync(path.join(warnDir, "AGENTS.md"), 0o644);
+      fs.rmSync(warnDir, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/cli/inject-references.test.ts
+++ b/tests/cli/inject-references.test.ts
@@ -3,6 +3,7 @@ import os from "os";
 import path from "path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
+  buildInjectionBlock,
   computeRelativePath,
   findInstructionFiles,
 } from "../../src/cli/inject-references";
@@ -39,5 +40,13 @@ describe("inject-references", () => {
     expect(computeRelativePath(".github/copilot-instructions.md")).toBe(
       "../.agents/linting-rules.md",
     );
+  });
+
+  it("buildInjectionBlock produces the delimited reference block", () => {
+    expect(buildInjectionBlock("../.agents/linting-rules.md"))
+      .toBe(`<!-- llm-core-instructions:start -->
+See [\`.agents/linting-rules.md\`](../.agents/linting-rules.md) for coding guidelines derived from your ESLint config.
+Regenerate with: \`npx llm-core-instructions\`
+<!-- llm-core-instructions:end -->`);
   });
 });

--- a/tests/cli/inject-references.test.ts
+++ b/tests/cli/inject-references.test.ts
@@ -54,6 +54,20 @@ describe("inject-references", () => {
     );
   });
 
+  it("computeRelativePath normalizes to forward slashes (win32 regression)", () => {
+    const result = path.win32.relative(
+      path.win32.dirname(".github\\copilot-instructions.md"),
+      ".agents\\linting-rules.md",
+    );
+    expect(result).toContain("\\");
+    expect(computeRelativePath(".github/copilot-instructions.md")).toBe(
+      "../.agents/linting-rules.md",
+    );
+    expect(
+      computeRelativePath(".github/copilot-instructions.md"),
+    ).not.toContain("\\");
+  });
+
   it("buildInjectionBlock produces the delimited reference block", () => {
     expect(buildInjectionBlock("../.agents/linting-rules.md"))
       .toBe(`<!-- llm-core-instructions:start -->

--- a/tests/cli/inject-references.test.ts
+++ b/tests/cli/inject-references.test.ts
@@ -117,6 +117,21 @@ Existing content
     expect(second).toBe(first);
   });
 
+  it("replaceOrAppendBlock appends when only orphaned end marker is present", () => {
+    const content = `# Title
+
+${injectionBlockEnd}
+
+Some content
+`;
+    const block = buildInjectionBlock(".agents/linting-rules.md");
+    const result = replaceOrAppendBlock(content, block);
+
+    expect(result).toContain(injectionBlockStart);
+    expect(result).toContain("# Title");
+    expect(result).toContain("Some content");
+  });
+
   it("findInstructionFiles returns empty array when no instruction files exist", () => {
     const emptyDir = fs.mkdtempSync(path.join(os.tmpdir(), "llm-core-empty-"));
     try {
@@ -218,6 +233,27 @@ describe("injectReferences integration", () => {
     } finally {
       fs.chmodSync(path.join(warnDir, "AGENTS.md"), 0o644);
       fs.rmSync(warnDir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns empty on re-run when content is unchanged", () => {
+    const idempotentDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "llm-core-idempotent-"),
+    );
+    try {
+      fs.writeFileSync(
+        path.join(idempotentDir, "AGENTS.md"),
+        "# Agents\n",
+        "utf-8",
+      );
+
+      const first = injectReferences(idempotentDir);
+      expect(first).toEqual(["AGENTS.md"]);
+
+      const second = injectReferences(idempotentDir);
+      expect(second).toEqual([]);
+    } finally {
+      fs.rmSync(idempotentDir, { recursive: true, force: true });
     }
   });
 });

--- a/tests/cli/inject-references.test.ts
+++ b/tests/cli/inject-references.test.ts
@@ -2,7 +2,10 @@ import fs from "fs";
 import os from "os";
 import path from "path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { findInstructionFiles } from "../../src/cli/inject-references";
+import {
+  computeRelativePath,
+  findInstructionFiles,
+} from "../../src/cli/inject-references";
 
 describe("inject-references", () => {
   let tmpDir = "";
@@ -28,5 +31,13 @@ describe("inject-references", () => {
       "AGENTS.md",
       ".github/copilot-instructions.md",
     ]);
+  });
+
+  it("computeRelativePath returns the correct path for root and .github files", () => {
+    expect(computeRelativePath("AGENTS.md")).toBe(".agents/linting-rules.md");
+    expect(computeRelativePath("CLAUDE.md")).toBe(".agents/linting-rules.md");
+    expect(computeRelativePath(".github/copilot-instructions.md")).toBe(
+      "../.agents/linting-rules.md",
+    );
   });
 });

--- a/tests/cli/inject-references.test.ts
+++ b/tests/cli/inject-references.test.ts
@@ -1,0 +1,32 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { findInstructionFiles } from "../../src/cli/inject-references";
+
+describe("inject-references", () => {
+  let tmpDir = "";
+
+  beforeAll(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "llm-core-inject-"));
+  });
+
+  afterAll(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("findInstructionFiles detects existing instruction files at the repo root", () => {
+    fs.writeFileSync(path.join(tmpDir, "AGENTS.md"), "# Agents\n", "utf-8");
+    fs.mkdirSync(path.join(tmpDir, ".github"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, ".github", "copilot-instructions.md"),
+      "# Copilot\n",
+      "utf-8",
+    );
+
+    expect(findInstructionFiles(tmpDir)).toEqual([
+      "AGENTS.md",
+      ".github/copilot-instructions.md",
+    ]);
+  });
+});

--- a/tests/instructions/e2e.test.ts
+++ b/tests/instructions/e2e.test.ts
@@ -222,4 +222,116 @@ describe("e2e: CLI generate-instructions", () => {
     expect(overwritten).toContain("# Coding Guidelines");
     expect(overwritten).toContain("under 30 lines");
   });
+
+  it("injects reference into existing AGENTS.md by default", async () => {
+    const injectDir = path.join(fixturesDir, "__tmp_inject_test__");
+    fs.mkdirSync(injectDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(injectDir, "AGENTS.md"),
+      "# Agents\n\nExisting content\n",
+      "utf-8",
+    );
+
+    try {
+      const { stdout, exitCode } = await runCli(
+        ["--config", customConfig],
+        injectDir,
+      );
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain("Injected reference into AGENTS.md");
+
+      const agentsContent = fs.readFileSync(
+        path.join(injectDir, "AGENTS.md"),
+        "utf-8",
+      );
+      expect(agentsContent).toContain("<!-- llm-core-instructions:start -->");
+      expect(agentsContent).toContain("<!-- llm-core-instructions:end -->");
+      expect(agentsContent).toContain(".agents/linting-rules.md");
+      expect(agentsContent).toContain("# Agents");
+      expect(agentsContent).toContain("Existing content");
+    } finally {
+      fs.rmSync(injectDir, { recursive: true, force: true });
+    }
+  });
+
+  it("--no-inject skips injection", async () => {
+    const noInjectDir = path.join(fixturesDir, "__tmp_no_inject_test__");
+    fs.mkdirSync(noInjectDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(noInjectDir, "CLAUDE.md"),
+      "# Claude\n",
+      "utf-8",
+    );
+
+    try {
+      const { stdout, exitCode } = await runCli(
+        ["--config", customConfig, "--no-inject"],
+        noInjectDir,
+      );
+      expect(exitCode).toBe(0);
+      expect(stdout).not.toContain("Injected reference");
+
+      const claudeContent = fs.readFileSync(
+        path.join(noInjectDir, "CLAUDE.md"),
+        "utf-8",
+      );
+      expect(claudeContent).toBe("# Claude\n");
+    } finally {
+      fs.rmSync(noInjectDir, { recursive: true, force: true });
+    }
+  });
+
+  it("--dry-run writes nothing to disk (no generated file, no injection)", async () => {
+    const dryRunDir = path.join(fixturesDir, "__tmp_dryrun_test__");
+    fs.mkdirSync(dryRunDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dryRunDir, "AGENTS.md"),
+      "# Original\n",
+      "utf-8",
+    );
+
+    try {
+      const { stdout, exitCode } = await runCli(
+        ["--config", customConfig, "--dry-run"],
+        dryRunDir,
+      );
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain("# Coding Guidelines");
+
+      expect(
+        fs.existsSync(path.join(dryRunDir, ".agents", "linting-rules.md")),
+      ).toBe(false);
+
+      const agentsContent = fs.readFileSync(
+        path.join(dryRunDir, "AGENTS.md"),
+        "utf-8",
+      );
+      expect(agentsContent).toBe("# Original\n");
+    } finally {
+      fs.rmSync(dryRunDir, { recursive: true, force: true });
+    }
+  });
+
+  it("--dry-run --no-inject behaves the same as --dry-run", async () => {
+    const bothDir = path.join(fixturesDir, "__tmp_both_test__");
+    fs.mkdirSync(bothDir, { recursive: true });
+    fs.writeFileSync(path.join(bothDir, "CLAUDE.md"), "# Original\n", "utf-8");
+
+    try {
+      const { stdout, exitCode } = await runCli(
+        ["--config", customConfig, "--dry-run", "--no-inject"],
+        bothDir,
+      );
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain("# Coding Guidelines");
+
+      const claudeContent = fs.readFileSync(
+        path.join(bothDir, "CLAUDE.md"),
+        "utf-8",
+      );
+      expect(claudeContent).toBe("# Original\n");
+    } finally {
+      fs.rmSync(bothDir, { recursive: true, force: true });
+    }
+  });
 });


### PR DESCRIPTION
## What does this PR do?

Closes #125

After generating `.agents/linting-rules.md`, the CLI now automatically appends a reference block into any existing agent instruction files (AGENTS.md, CLAUDE.md, .github/copilot-instructions.md) so agent tools discover the generated guidelines without manual wiring.

Re-running replaces the block in-place via `<!-- llm-core-instructions:start/end -->` markers — no duplicates. Use `--no-inject` to skip injection.

Also fixes three discoverability issues in the instruction files that caused an agent to skip the BASELINE and VERIFY workflow steps.

## Verification

### Detection

✅ Hit: CLI run with AGENTS.md present → "Injected reference into AGENTS.md" logged, block appended with correct `.agents/linting-rules.md` path
✅ Hit: CLI run with .github/copilot-instructions.md present → block appended with correct `../.agents/linting-rules.md` path
✅ Clean: `--no-inject` → no files modified, no "Injected reference" output
✅ Clean: `--dry-run` → nothing written to disk

### Tests (14 new, 729 total)

Unit tests (10):
- Detection: `findInstructionFiles` detects existing files, returns empty for missing
- Path computation: correct for root files and `.github/`
- Block building: produces correct delimited block
- Idempotent replacement: replaces in-place, appends when missing, re-running produces identical output
- Integration: injects into all files preserving content, skips missing, handles unwritable with stderr warning

CLI e2e (4):
- Default injection into existing AGENTS.md
- `--no-inject` skips injection
- `--dry-run` writes nothing to disk
- `--dry-run --no-inject` equivalent to `--dry-run` alone

### Manual verification

- Built CLI run against real repo files: all three targets injected with correct relative paths
- Re-run produced identical file hashes (idempotent)
- `--dry-run` outputs markdown to stdout, writes nothing

### Contract

- [x] Library API (`generateInstructions`) unchanged — all 715 original tests pass
- [x] `--no-inject` flag added to CLI argument parsing
- [x] `--dry-run` behavior unchanged (writes nothing)
- [x] Injection module is CLI-only, not in library API

## Checklist

- [x] `npm run build` passes
- [x] `npm run test` passes (new tests added if applicable)
- [x] `npm run lint` passes
- [x] `npm run update:eslint-docs` ran (N/A — no rules changed)
- [x] Docs added/updated (N/A — no new rules)
- [x] Rule exported in `src/rules/index.ts` (N/A — no new rules)
- [x] Rule added to `recommendedRules` in `src/index.ts` (N/A — no new rules)

## Agent Disclosure

**Agent:** Sisyphus (OpenCode)

**Instruction files loaded:**

- [x] `.github/copilot-instructions.md`
- [x] `.github/instructions/rule-implementation.md`
- [x] `.github/instructions/rule-tests.md`
- [x] `.github/instructions/rule-docs.md`
- [x] `.github/instructions/plugin-config.md`
- [x] `AGENTS.md`
- [x] `.agents/directives/TYPE_DRIVEN_DEVELOPMENT.md`
- [x] `.agents/directives/TEST_DRIVEN_DEVELOPMENT.md`
- [x] `.agents/directives/VERIFICATION.md`
- [x] `.agents/directives/SESSION_DECISIONS.md`
- [ ] If `SESSION_DECISIONS.md` was loaded **and** this PR set a durable repo/process or cross-cutting decision whose reasoning is not obvious from the diff, a `docs/decisions/YYYY-MM-DD-<topic>.md` entry is included in this PR — N/A, no durable decisions set

**Instruction files NOT loaded (explain if unexpected):**

None — all scoped instruction files were loaded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--no-inject` CLI flag to skip automatic reference injection.
  * CLI now automatically injects linting rules references into instruction files with idempotent re-run behavior.

* **Documentation**
  * Updated verification guidance to apply to all code changes, with specific requirements by change type.
  * Added baseline and verification steps to contribution workflow.
  * Updated README with new flag documentation.

* **Tests**
  * Added comprehensive test coverage for reference injection functionality and end-to-end CLI behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->