### PR TITLE
fix: publish MCP package metadata

### DIFF
--- a/.changeset/quiet-shoes-smile.md
+++ b/.changeset/quiet-shoes-smile.md
@@ -1,0 +1,6 @@
+---
+"eslint-plugin-llm-core": patch
+"eslint-plugin-llm-core-mcp": patch
+---
+
+Fix MCP package publishing metadata and configure the release workflow to provide npm authentication for package publishing.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 22
+          registry-url: https://registry.npmjs.org
           cache: npm
       - run: npm ci
       - run: npm run build
@@ -33,6 +34,8 @@ jobs:
       - name: Publish to npm
         id: publish
         if: steps.changesets.outputs.hasChangesets == 'false'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           CURRENT_VERSION=$(node -p "require('./package.json').version")
           MCP_VERSION=$(node -p "require('./packages/mcp-server/package.json').version")

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -12,7 +12,7 @@
     }
   },
   "bin": {
-    "llm-core-mcp": "./dist/server.js"
+    "llm-core-mcp": "dist/server.js"
   },
   "files": [
     "dist"

--- a/packages/mcp-server/tests/package.test.ts
+++ b/packages/mcp-server/tests/package.test.ts
@@ -27,7 +27,7 @@ describe("MCP package metadata", () => {
       files?: string[];
     };
 
-    expect(pkg.bin?.["llm-core-mcp"]).toBe("./dist/server.js");
+    expect(pkg.bin?.["llm-core-mcp"]).toBe("dist/server.js");
     expect(pkg.files).toContain("dist");
   });
 


### PR DESCRIPTION
## What does this PR do?

Fixes the MCP package publish follow-up after the v1 release failure:

- Provides npm auth to the release workflow via `NODE_AUTH_TOKEN`.
- Sets the MCP package `bin` entry to `dist/server.js` so npm keeps the executable metadata.
- Updates the MCP package metadata test to match the published manifest.
- Adds a patch changeset for both packages to preserve lockstep versioning.

## Verification

- `npm run format:check` passes
- `npm run lint` passes
- `npm run test` passes: 52 core test files / 876 tests and 5 MCP test files / 25 tests
- `npm run build` passes
- `npm --workspace eslint-plugin-llm-core-mcp pack --dry-run` passes and preserves the MCP package tarball metadata without npm bin warnings

## Debugging Summary

- Symptom: PR #192 failed `Changeset Presence` because `packages/mcp-server/package.json` changed without a `.changeset/*.md` file.
- Root cause: the CI check treats package manifests as release-affecting inputs, so this metadata fix requires a changeset even though no source behavior changed.
- Fix: added a patch changeset for `eslint-plugin-llm-core` and `eslint-plugin-llm-core-mcp`, matching the MCP v1 lockstep release policy.

## Release Follow-Up

Before rerunning release, add an `NPM_TOKEN` repository secret with publish access. After `eslint-plugin-llm-core-mcp` exists on npm, configure npm Trusted Publishing for that package and rotate/remove the token path.

## Checklist

- [x] `npm run build` passes
- [x] `npm run test` passes (new tests added if applicable)
- [x] `npm run lint` passes
- [x] `npm run update:eslint-docs` ran (if rules were added or changed) — N/A, no rule docs changed
- [x] Docs added/updated (if adding a new rule: `docs/rules/<rule-name>.md`) — N/A, no new rule
- [x] Rule exported in `src/rules/index.ts` (if adding a new rule) — N/A, no new rule
- [x] Rule added to `recommendedRules` in `src/index.ts` (if applicable) — N/A, no new rule

## Agent Disclosure (complete if this PR was authored by an AI agent)

**Agent:** Codex

**Instruction files loaded:**

- [x] `AGENTS.md`
- [x] `.agents/directives/adaptive-routing.md`
- [x] `.agents/skills/systematic-debugging/SKILL.md`
- [x] `.github/instructions/pull-request.md`

**Instruction files NOT loaded (explain if unexpected):**

- Rule-specific instruction files were not loaded because this PR does not modify ESLint rule source, rule tests, generated rule docs, plugin config, or recommended rule exports.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed MCP package publishing metadata configuration and export path

* **Chores**
  * Updated release workflow to configure npm registry authentication for package publishing

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pertrai1/eslint-plugin-llm-core/pull/192?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->