### PR TITLE
fix: add MCP repository metadata

### DIFF
--- a/.changeset/neat-buckets-cross.md
+++ b/.changeset/neat-buckets-cross.md
@@ -1,0 +1,6 @@
+---
+"eslint-plugin-llm-core": patch
+"eslint-plugin-llm-core-mcp": patch
+---
+
+Add MCP package repository metadata required for npm provenance validation.

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -3,6 +3,11 @@
   "version": "0.25.1",
   "description": "MCP server for just-in-time linting guidance from eslint-plugin-llm-core",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/pertrai1/eslint-plugin-llm-core",
+    "directory": "packages/mcp-server"
+  },
   "type": "module",
   "main": "dist/index.js",
   "exports": {

--- a/packages/mcp-server/tests/package.test.ts
+++ b/packages/mcp-server/tests/package.test.ts
@@ -31,6 +31,22 @@ describe("MCP package metadata", () => {
     expect(pkg.files).toContain("dist");
   });
 
+  it("declares repository metadata for npm provenance validation", async () => {
+    const pkg = JSON.parse(await readFile(PACKAGE_JSON, "utf8")) as {
+      repository?: {
+        type?: string;
+        url?: string;
+        directory?: string;
+      };
+    };
+
+    expect(pkg.repository).toEqual({
+      type: "git",
+      url: "https://github.com/pertrai1/eslint-plugin-llm-core",
+      directory: "packages/mcp-server",
+    });
+  });
+
   it("ships package-level setup documentation", async () => {
     await expect(access(README, constants.R_OK)).resolves.toBeUndefined();
 


### PR DESCRIPTION
## What does this PR do?

Fixes the MCP package publish failure from the release workflow by adding repository metadata to `packages/mcp-server/package.json`.

The failed npm publish reached provenance validation, then rejected `eslint-plugin-llm-core-mcp` because the package manifest did not declare a `repository.url` matching the GitHub Actions provenance source:

```text
E422 Unprocessable Entity
package.json: "repository.url" is "", expected to match "https://github.com/pertrai1/eslint-plugin-llm-core"
```

This PR also adds package metadata test coverage and a patch changeset for both packages to preserve lockstep versioning.

## Verification

- `npm --workspace eslint-plugin-llm-core-mcp test` passes: 5 files / 26 tests
- `npm --workspace eslint-plugin-llm-core-mcp pack --dry-run` passes and includes the updated package manifest
- `npm run format:check` passes
- `npm run build` passes
- `npm run lint` passes
- `npm run test` passes: 52 core files / 876 tests and 5 MCP files / 26 tests
- `git diff --check` passes

## Debugging Summary

- Symptom: rerun of the release job failed while publishing `eslint-plugin-llm-core-mcp@0.25.1`.
- Root cause: npm provenance validation requires the package manifest repository URL to match the GitHub Actions provenance repository, but the MCP package manifest had no `repository` field.
- Fix: added `repository.type`, `repository.url`, and `repository.directory` to the MCP package manifest and covered it with a package metadata test.

## Checklist

- [x] `npm run build` passes
- [x] `npm run test` passes (new tests added if applicable)
- [x] `npm run lint` passes
- [x] `npm run update:eslint-docs` ran (if rules were added or changed) - N/A, no rule docs changed
- [x] Docs added/updated (if adding a new rule: `docs/rules/<rule-name>.md`) - N/A, no new rule
- [x] Rule exported in `src/rules/index.ts` (if adding a new rule) - N/A, no new rule
- [x] Rule added to `recommendedRules` in `src/index.ts` (if applicable) - N/A, no new rule

## Agent Disclosure (complete if this PR was authored by an AI agent)

**Agent:** Codex

**Instruction files loaded:**

- [x] `AGENTS.md`
- [x] `.agents/directives/adaptive-routing.md`
- [x] `.agents/skills/systematic-debugging/SKILL.md`
- [x] `.github/instructions/pull-request.md`
- [x] `github:yeet` skill

**Instruction files NOT loaded (explain if unexpected):**

- Rule-specific instruction files were not loaded because this PR does not modify ESLint rule source, rule tests, generated rule docs, plugin config, or recommended rule exports.
