### PR TITLE
ci: remove npm token publish fallback

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,8 +34,6 @@ jobs:
       - name: Publish to npm
         id: publish
         if: steps.changesets.outputs.hasChangesets == 'false'
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           CURRENT_VERSION=$(node -p "require('./package.json').version")
           MCP_VERSION=$(node -p "require('./packages/mcp-server/package.json').version")


### PR DESCRIPTION
## What does this PR do?

Removes the temporary `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` publish fallback from the release workflow now that both npm packages exist and Trusted Publishing is configured for the GitHub Actions release workflow.

The workflow keeps the required Trusted Publishing pieces:

- `permissions.id-token: write`
- `actions/setup-node` with `registry-url: https://registry.npmjs.org`
- `npm publish --provenance`

## Verification

- `npm run format:check` passes
- Release workflow YAML parses successfully with Ruby YAML
- `git diff --check` passes

## Checklist

- [x] `npm run build` passes - N/A, workflow-only auth cleanup
- [x] `npm run test` passes (new tests added if applicable) - N/A, workflow-only auth cleanup
- [x] `npm run lint` passes - N/A, workflow-only auth cleanup
- [x] `npm run update:eslint-docs` ran (if rules were added or changed) - N/A, no rule docs changed
- [x] Docs added/updated (if adding a new rule: `docs/rules/<rule-name>.md`) - N/A, no new rule
- [x] Rule exported in `src/rules/index.ts` (if adding a new rule) - N/A, no new rule
- [x] Rule added to `recommendedRules` in `src/index.ts` (if applicable) - N/A, no new rule

## Agent Disclosure (complete if this PR was authored by an AI agent)

**Agent:** Codex

**Instruction files loaded:**

- [x] `AGENTS.md`
- [x] `.agents/directives/adaptive-routing.md`
- [x] `github:yeet` skill

**Instruction files NOT loaded (explain if unexpected):**

- Rule-specific instruction files and debugging skills were not loaded because this PR only removes the temporary npm token fallback from release workflow configuration after Trusted Publishing was configured.
