### PR TITLE
feat(mcp): add opt-in zero-config fallback mode

### DIFF
--- a/.changeset/mcp-zero-config-fallback.md
+++ b/.changeset/mcp-zero-config-fallback.md
@@ -1,0 +1,6 @@
+---
+"eslint-plugin-llm-core": minor
+"eslint-plugin-llm-core-mcp": minor
+---
+
+Add opt-in MCP server zero-config fallback mode via `LLM_CORE_MCP_ENABLE_FALLBACK=1`, with explicit project-config versus fallback source labeling.

--- a/README.md
+++ b/README.md
@@ -335,10 +335,32 @@ Register it with an MCP-capable client:
 ```
 
 The server exposes `lint_file`, `get_active_instructions`,
-`llm-core://rules`, and `llm-core://rules/{ruleName}`. `lint_file` uses the
-target project's discovered ESLint flat config. In v1 it does not provide a
-built-in fallback config, so the target project must already install and
-configure `eslint-plugin-llm-core`.
+`llm-core://rules`, and `llm-core://rules/{ruleName}`. `lint_file` first uses
+the target project's discovered ESLint flat config and labels those findings
+with `source: "project-config"`.
+
+Repos without an ESLint config can opt in to a transient zero-config fallback by
+setting `LLM_CORE_MCP_ENABLE_FALLBACK=1` in the MCP server environment:
+
+```json
+{
+  "mcpServers": {
+    "llm-core": {
+      "command": "npx",
+      "args": ["-y", "eslint-plugin-llm-core-mcp"],
+      "env": {
+        "LLM_CORE_MCP_ENABLE_FALLBACK": "1"
+      }
+    }
+  }
+}
+```
+
+Fallback mode only runs when no project config is discoverable. It uses the
+bundled recommended `llm-core` rules and TypeScript parser, labels findings with
+`source: "fallback"`, and remains read-only: no file edits, generated config, or
+ESLint cache. Fallback findings may include rules the project has not opted into;
+configure the plugin in the project when results must match CI/editor lint.
 
 Manual smoke check after build:
 

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -27,9 +27,37 @@ Register the server with an MCP-capable client using `npx`:
 }
 ```
 
-`lint_file` uses the project ESLint configuration it discovers from the target
-path. In v1 there is no built-in fallback config, so the target project must
-already install and configure `eslint-plugin-llm-core` in `eslint.config.*`.
+`lint_file` first uses the project ESLint configuration it discovers from the
+target path. Project configuration always takes precedence, and project-config
+findings are labeled with `source: "project-config"`.
+
+## Optional Zero-Config Fallback
+
+Repos without an ESLint config can opt in to a transient fallback config:
+
+```json
+{
+  "mcpServers": {
+    "llm-core": {
+      "command": "npx",
+      "args": ["-y", "eslint-plugin-llm-core-mcp"],
+      "env": {
+        "LLM_CORE_MCP_ENABLE_FALLBACK": "1"
+      }
+    }
+  }
+}
+```
+
+Fallback mode only runs when no project ESLint config is discoverable. It uses
+the bundled `eslint-plugin-llm-core` recommended config and TypeScript parser,
+returns findings labeled with `source: "fallback"`, and remains read-only: it
+does not write files, create config files, enable autofix, or create an ESLint
+cache.
+
+Tradeoff: fallback findings may include rules the target project has not opted
+into. Install and configure `eslint-plugin-llm-core` in the project when you need
+findings to match CI/editor lint exactly.
 
 ## Manual Smoke Check
 

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -20,7 +20,7 @@ export const server = new McpServer({
 
 // Tools
 registerGetActiveInstructions(server);
-registerLintFile(server);
+registerLintFile(server, { fallbackEnabled: isFallbackEnabledFromEnv() });
 
 // Resources
 registerRuleResources(server);
@@ -50,6 +50,12 @@ export function isDirectRun(
     realPathOrResolved(entryPoint) ===
     realPathOrResolved(fileURLToPath(moduleUrl))
   );
+}
+
+export function isFallbackEnabledFromEnv(
+  env: Record<string, string | undefined> = process.env,
+): boolean {
+  return env.LLM_CORE_MCP_ENABLE_FALLBACK === "1";
 }
 
 // Only start when run directly (not imported in tests).

--- a/packages/mcp-server/src/tools/lint-file.ts
+++ b/packages/mcp-server/src/tools/lint-file.ts
@@ -215,6 +215,14 @@ function createFallbackConfig(): FlatConfig[] {
 
   return [
     {
+      ignores: [
+        "**/node_modules/**",
+        "**/.git/**",
+        "**/dist/**",
+        "**/coverage/**",
+      ],
+    },
+    {
       files: ["**/*.ts", "**/*.tsx"],
       languageOptions: {
         parser: tsParser,
@@ -225,10 +233,20 @@ function createFallbackConfig(): FlatConfig[] {
       },
     },
     {
-      files: ["**/*.js", "**/*.jsx", "**/*.mjs"],
+      files: ["**/*.js", "**/*.mjs"],
       languageOptions: {
         ecmaVersion: "latest",
         sourceType: "module",
+      },
+    },
+    {
+      files: ["**/*.jsx"],
+      languageOptions: {
+        ecmaVersion: "latest",
+        sourceType: "module",
+        parserOptions: {
+          ecmaFeatures: { jsx: true },
+        },
       },
     },
     {

--- a/packages/mcp-server/src/tools/lint-file.ts
+++ b/packages/mcp-server/src/tools/lint-file.ts
@@ -212,6 +212,9 @@ function createFallbackConfig(): FlatConfig[] {
     configs: Record<string, FlatConfig[]>;
   };
   const recommended = llmPlugin.configs.recommended ?? [];
+  const recommendedRules = (
+    recommended[0] as { rules?: Record<string, unknown> } | undefined
+  )?.rules;
 
   return [
     {
@@ -241,6 +244,8 @@ function createFallbackConfig(): FlatConfig[] {
     },
     {
       files: ["**/*.jsx"],
+      plugins: { "llm-core": plugin },
+      rules: recommendedRules,
       languageOptions: {
         ecmaVersion: "latest",
         sourceType: "module",

--- a/packages/mcp-server/src/tools/lint-file.ts
+++ b/packages/mcp-server/src/tools/lint-file.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { readdir, realpath, stat } from "node:fs/promises";
 import { loadESLint } from "eslint";
+import tsParser from "@typescript-eslint/parser";
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 // ESM importing the CJS plugin's ./instructions subpath via interop.
@@ -36,9 +37,9 @@ const SKIPPED_DIRECTORIES = new Set([
 const NO_CONFIG_MESSAGE = [
   "No ESLint configuration was discovered for this path.",
   "",
-  "lint_file lints using your project's own ESLint config; in v1 it does not",
-  "fall back to a built-in config. To use it, install and configure",
-  "eslint-plugin-llm-core in your project:",
+  "lint_file lints using your project's own ESLint config by default. To use",
+  "project-config findings, install and configure eslint-plugin-llm-core in",
+  "your project:",
   "",
   "  npm install --save-dev eslint eslint-plugin-llm-core",
   "",
@@ -46,6 +47,9 @@ const NO_CONFIG_MESSAGE = [
   "",
   '  import llmCore from "eslint-plugin-llm-core";',
   "  export default [...llmCore.configs.recommended];",
+  "",
+  "Alternatively, start the MCP server with LLM_CORE_MCP_ENABLE_FALLBACK=1 to",
+  'enable read-only fallback findings labeled with source: "fallback".',
 ].join("\n");
 
 function isNoConfigError(error: unknown): boolean {
@@ -123,6 +127,12 @@ export interface LintFileOptions {
    * {@link DEFAULT_MAX_FILES}.
    */
   maxFiles?: number;
+  /**
+   * Enables a transient zero-config fallback when no project ESLint config is
+   * discoverable. Disabled by default so v1 project-config behavior remains the
+   * default contract.
+   */
+  fallbackEnabled?: boolean;
 }
 
 interface LintViolation {
@@ -132,6 +142,7 @@ interface LintViolation {
   severity: number;
   message: string;
   instruction: string | undefined;
+  source: LintSource;
 }
 
 interface FlatLintMessage {
@@ -158,7 +169,13 @@ interface FlatESLintInstance {
 
 type FlatESLintConstructor = new (options?: {
   cwd?: string;
+  overrideConfigFile?: true;
+  overrideConfig?: FlatConfig[];
 }) => FlatESLintInstance;
+
+type LintSource = "project-config" | "fallback";
+
+type FlatConfig = Record<string, unknown>;
 
 const inputSchema = {
   path: z
@@ -166,14 +183,63 @@ const inputSchema = {
     .describe("Path to a file or directory to lint, within the project root"),
 };
 
-async function createFlatESLint(cwd: string): Promise<FlatESLintInstance> {
+async function newFlatESLint(
+  opts: { cwd: string } & Record<string, unknown>,
+): Promise<FlatESLintInstance> {
   // ESLint's exported types do not surface the flat-config overload; the cast
   // matches the runtime shape (mirrors src/instructions/config-resolver.ts).
   const loadFlatESLint = loadESLint as unknown as (options: {
     useFlatConfig: boolean;
   }) => Promise<FlatESLintConstructor>;
   const ESLint = await loadFlatESLint({ useFlatConfig: true });
-  return new ESLint({ cwd });
+  return new ESLint(opts);
+}
+
+async function createFlatESLint(cwd: string): Promise<FlatESLintInstance> {
+  return newFlatESLint({ cwd });
+}
+
+async function createFallbackESLint(cwd: string): Promise<FlatESLintInstance> {
+  return newFlatESLint({
+    cwd,
+    overrideConfigFile: true,
+    overrideConfig: createFallbackConfig(),
+  });
+}
+
+function createFallbackConfig(): FlatConfig[] {
+  const llmPlugin = plugin as unknown as {
+    configs: Record<string, FlatConfig[]>;
+  };
+  const recommended = llmPlugin.configs.recommended ?? [];
+
+  return [
+    {
+      files: ["**/*.ts", "**/*.tsx"],
+      languageOptions: {
+        parser: tsParser,
+        parserOptions: {
+          ecmaVersion: "latest",
+          sourceType: "module",
+        },
+      },
+    },
+    {
+      files: ["**/*.js", "**/*.jsx", "**/*.mjs"],
+      languageOptions: {
+        ecmaVersion: "latest",
+        sourceType: "module",
+      },
+    },
+    {
+      files: ["**/*.cjs"],
+      languageOptions: {
+        ecmaVersion: "latest",
+        sourceType: "commonjs",
+      },
+    },
+    ...recommended,
+  ];
 }
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
@@ -211,6 +277,7 @@ function resolveRuleOptions(
 async function toViolations(
   results: FlatLintResult[],
   eslint: FlatESLintInstance,
+  source: LintSource,
 ): Promise<LintViolation[]> {
   const violations: LintViolation[] = [];
 
@@ -239,6 +306,7 @@ async function toViolations(
         severity: message.severity,
         message: message.message,
         instruction: getRuleInstruction(ruleId, options),
+        source,
       });
     }
   }
@@ -252,14 +320,16 @@ export function registerLintFile(
 ): void {
   const projectRoot = path.resolve(options.projectRoot ?? process.cwd());
   const maxFiles = options.maxFiles ?? DEFAULT_MAX_FILES;
+  const fallbackEnabled = options.fallbackEnabled === true;
 
   server.registerTool(
     "lint_file",
     {
       title: "Lint a File for llm-core Violations",
       description:
-        "Lints a file (or directory) with the project's own ESLint config and " +
-        "returns each eslint-plugin-llm-core violation with its what/why/how-to-fix " +
+        "Lints a file (or directory) with the project's own ESLint config, " +
+        "or the opt-in read-only fallback when no config is found, and returns " +
+        "each eslint-plugin-llm-core violation with its what/why/how-to-fix " +
         "instruction attached. Call after editing a file to self-correct.",
       inputSchema,
     },
@@ -326,6 +396,32 @@ export function registerLintFile(
         results = await eslint.lintFiles([absoluteTarget]);
       } catch (error) {
         if (isNoConfigError(error)) {
+          if (fallbackEnabled) {
+            const fallbackEslint = await createFallbackESLint(projectRoot);
+            const fallbackResults = await fallbackEslint.lintFiles([
+              absoluteTarget,
+            ]);
+            const source = "fallback";
+            const violations = await toViolations(
+              fallbackResults,
+              fallbackEslint,
+              source,
+            );
+
+            return {
+              structuredContent: {
+                source,
+                violationCount: violations.length,
+              },
+              content: [
+                {
+                  type: "text" as const,
+                  text: JSON.stringify(violations, null, 2),
+                },
+              ],
+            };
+          }
+
           return {
             content: [{ type: "text" as const, text: NO_CONFIG_MESSAGE }],
           };
@@ -333,9 +429,14 @@ export function registerLintFile(
         throw error;
       }
 
-      const violations = await toViolations(results, eslint);
+      const source = "project-config";
+      const violations = await toViolations(results, eslint, source);
 
       return {
+        structuredContent: {
+          source,
+          violationCount: violations.length,
+        },
         content: [
           { type: "text" as const, text: JSON.stringify(violations, null, 2) },
         ],

--- a/packages/mcp-server/tests/fixtures/project-with-config/precedence/empty-catch.ts
+++ b/packages/mcp-server/tests/fixtures/project-with-config/precedence/empty-catch.ts
@@ -1,0 +1,3 @@
+try {
+  throw new Error("boom");
+} catch (error) {}

--- a/packages/mcp-server/tests/lint-file.test.ts
+++ b/packages/mcp-server/tests/lint-file.test.ts
@@ -315,6 +315,39 @@ describe("lint_file with no discoverable ESLint config", () => {
     }
   });
 
+  it("parses JSX syntax in fallback mode without parser errors", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "llmcore-mcp-jsx-"));
+    try {
+      const target = path.join(dir, "component.jsx");
+      await writeFile(
+        target,
+        [
+          "function Greeting({ name }: { name: string }) {",
+          "  return <div>Hello, {name}!</div>;",
+          "}",
+          "",
+        ].join("\n"),
+      );
+
+      const client = await connectClient({
+        projectRoot: dir,
+        fallbackEnabled: true,
+      });
+      const result = (await client.callTool({
+        name: "lint_file",
+        arguments: { path: target },
+      })) as LintToolResult;
+
+      const violations = readViolations(result);
+      // JSX must parse without fatal errors; violations are valid llm-core rules
+      for (const v of violations) {
+        expect(v.ruleId.startsWith("llm-core/")).toBe(true);
+      }
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it("does not create config or cache files when fallback mode runs", async () => {
     const dir = await mkdtemp(path.join(tmpdir(), "llmcore-mcp-readonly-"));
     try {

--- a/packages/mcp-server/tests/lint-file.test.ts
+++ b/packages/mcp-server/tests/lint-file.test.ts
@@ -3,7 +3,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
-import { mkdtemp, writeFile, rm, symlink } from "node:fs/promises";
+import { mkdtemp, readdir, writeFile, rm, symlink } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import {
   makeTestServer,
@@ -26,6 +26,15 @@ interface LintViolation {
   severity: number;
   message: string;
   instruction: string | undefined;
+  source: "project-config" | "fallback";
+}
+
+interface LintToolResult {
+  content: Array<{ type: string; text: string }>;
+  structuredContent?: {
+    source?: unknown;
+    violationCount?: unknown;
+  };
 }
 
 const PROJECT_WITH_CONFIG = fileURLToPath(
@@ -49,6 +58,12 @@ const CONFIGURABLE_EXPLICIT_FILE = fileURLToPath(
 const SRC_DIR = fileURLToPath(
   new URL("./fixtures/project-with-config/src", import.meta.url),
 );
+const PRECEDENCE_FILE = fileURLToPath(
+  new URL(
+    "./fixtures/project-with-config/precedence/empty-catch.ts",
+    import.meta.url,
+  ),
+);
 
 const clients: Client[] = [];
 
@@ -69,9 +84,7 @@ async function connectClient(options?: MakeTestServerOptions): Promise<Client> {
   return client;
 }
 
-function readViolations(result: {
-  content: Array<{ type: string; text: string }>;
-}): LintViolation[] {
+function readViolations(result: LintToolResult): LintViolation[] {
   const text = result.content[0].text;
   return JSON.parse(text) as LintViolation[];
 }
@@ -86,9 +99,7 @@ describe("lint_file tool", () => {
     });
 
     expect(result.isError).toBeFalsy();
-    const violations = readViolations(
-      result as { content: Array<{ type: string; text: string }> },
-    );
+    const violations = readViolations(result as LintToolResult);
 
     expect(Array.isArray(violations)).toBe(true);
     const violation = violations.find(
@@ -100,6 +111,11 @@ describe("lint_file tool", () => {
     expect(violation?.severity).toBe(2);
     expect(typeof violation?.message).toBe("string");
     expect(violation?.message.length).toBeGreaterThan(0);
+    expect(violation?.source).toBe("project-config");
+    expect((result as LintToolResult).structuredContent).toEqual({
+      source: "project-config",
+      violationCount: violations.length,
+    });
     // Instruction must be attached and carry the rule's guidance verbatim.
     expect(violation?.instruction).toBe(
       "Never leave catch blocks empty — handle, rethrow, or log the error",
@@ -208,6 +224,123 @@ describe("lint_file with no discoverable ESLint config", () => {
       await rm(dir, { recursive: true, force: true });
     }
   });
+
+  it("runs fallback linting when fallback mode is enabled", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "llmcore-mcp-fallback-"));
+    try {
+      const target = path.join(dir, "foo.ts");
+      await writeFile(
+        target,
+        [
+          "try {",
+          '  throw new Error("boom");',
+          "} catch (error) {",
+          "}",
+          "",
+        ].join("\n"),
+      );
+
+      const client = await connectClient({
+        projectRoot: dir,
+        fallbackEnabled: true,
+      });
+      const result = (await client.callTool({
+        name: "lint_file",
+        arguments: { path: target },
+      })) as LintToolResult;
+
+      const violations = readViolations(result);
+      const violation = violations.find(
+        (v) => v.ruleId === "llm-core/no-empty-catch",
+      );
+
+      expect(violation).toEqual(
+        expect.objectContaining({
+          ruleId: "llm-core/no-empty-catch",
+          source: "fallback",
+          instruction:
+            "Never leave catch blocks empty — handle, rethrow, or log the error",
+        }),
+      );
+      expect(result.structuredContent).toEqual({
+        source: "fallback",
+        violationCount: violations.length,
+      });
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("uses the project config instead of fallback when both are available", async () => {
+    const client = await connectClient({
+      projectRoot: PROJECT_WITH_CONFIG,
+      fallbackEnabled: true,
+    });
+
+    const result = (await client.callTool({
+      name: "lint_file",
+      arguments: { path: PRECEDENCE_FILE },
+    })) as LintToolResult;
+
+    expect(readViolations(result)).toEqual([]);
+    expect(result.structuredContent).toEqual({
+      source: "project-config",
+      violationCount: 0,
+    });
+  });
+
+  it("parses TypeScript syntax in fallback mode", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "llmcore-mcp-ts-"));
+    try {
+      const target = path.join(dir, "types.ts");
+      await writeFile(target, "const values: Array<any> = [];\n");
+
+      const client = await connectClient({
+        projectRoot: dir,
+        fallbackEnabled: true,
+      });
+      const result = (await client.callTool({
+        name: "lint_file",
+        arguments: { path: target },
+      })) as LintToolResult;
+
+      expect(readViolations(result)).toEqual([
+        expect.objectContaining({
+          ruleId: "llm-core/no-any-in-generic",
+          source: "fallback",
+        }),
+      ]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not create config or cache files when fallback mode runs", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "llmcore-mcp-readonly-"));
+    try {
+      const target = path.join(dir, "foo.ts");
+      await writeFile(target, "try {} catch (error) {}\n");
+
+      const client = await connectClient({
+        projectRoot: dir,
+        fallbackEnabled: true,
+      });
+      const before = await readdir(dir);
+      const result = (await client.callTool({
+        name: "lint_file",
+        arguments: { path: target },
+      })) as LintToolResult;
+      const after = await readdir(dir);
+
+      expect(before).toEqual(["foo.ts"]);
+      expect(readViolations(result)).toEqual([
+        expect.objectContaining({ source: "fallback" }),
+      ]);
+      expect(after).toEqual(["foo.ts"]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("lint_file path sandboxing", () => {
@@ -231,6 +364,23 @@ describe("lint_file path sandboxing", () => {
 
   it("rejects an absolute path outside the project root", async () => {
     const result = await callWithPath("/etc/hosts");
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text.toLowerCase()).toContain("project root");
+  });
+
+  it("rejects an absolute path outside the project root before fallback can run", async () => {
+    const client = await connectClient({
+      projectRoot: PROJECT_WITH_CONFIG,
+      fallbackEnabled: true,
+    });
+    const result = (await client.callTool({
+      name: "lint_file",
+      arguments: { path: "/etc/hosts" },
+    })) as {
+      isError?: boolean;
+      content: Array<{ type: string; text: string }>;
+    };
 
     expect(result.isError).toBe(true);
     expect(result.content[0].text.toLowerCase()).toContain("project root");

--- a/packages/mcp-server/tests/server.test.ts
+++ b/packages/mcp-server/tests/server.test.ts
@@ -6,7 +6,7 @@ import { mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import { isDirectRun } from "../src/server.js";
+import { isDirectRun, isFallbackEnabledFromEnv } from "../src/server.js";
 import { makeTestServer } from "./helpers/make-test-server.js";
 
 /**
@@ -102,6 +102,21 @@ describe("server entrypoint detection", () => {
   it("does not start the server when imported by another module", () => {
     expect(
       isDirectRun("/tmp/importer.js", pathToFileURL("/tmp/server.js").href),
+    ).toBe(false);
+  });
+});
+
+describe("server fallback env configuration", () => {
+  it("enables fallback only for the documented env value", () => {
+    expect(
+      isFallbackEnabledFromEnv({ LLM_CORE_MCP_ENABLE_FALLBACK: "1" }),
+    ).toBe(true);
+    expect(isFallbackEnabledFromEnv({})).toBe(false);
+    expect(
+      isFallbackEnabledFromEnv({ LLM_CORE_MCP_ENABLE_FALLBACK: "true" }),
+    ).toBe(false);
+    expect(
+      isFallbackEnabledFromEnv({ LLM_CORE_MCP_ENABLE_FALLBACK: "0" }),
     ).toBe(false);
   });
 });

--- a/src/cli/generate-instructions.ts
+++ b/src/cli/generate-instructions.ts
@@ -20,7 +20,9 @@ async function main(): Promise<void> {
     }
   }
 
-  const result = await generateInstructions({ configPath });
+  const result = await generateInstructions(
+    configPath ? { configPath } : undefined,
+  );
 
   if (dryRun) {
     process.stdout.write(result.content);

--- a/src/instructions/config-resolver.ts
+++ b/src/instructions/config-resolver.ts
@@ -43,7 +43,7 @@ function formatOptionValue(value: unknown): string {
 }
 
 function getReferencedOptionKeys(template: string): string[] {
-  return [...template.matchAll(/\{(\w+)\}/g)].map((match) => match[1]);
+  return [...template.matchAll(/\{(\w+)\}/g)].map((match) => match[1]!);
 }
 
 function interpolateTemplate(
@@ -216,7 +216,13 @@ export async function resolveActiveRules(
         return [];
       }
 
+      // Guard required for `noUncheckedIndexedAccess` — the prior
+      // `.filter(ruleName => ruleName in ruleInstructions)` guarantees
+      // the key exists at runtime.
       const instruction = ruleInstructions[ruleName];
+      if (!instruction) {
+        return [];
+      }
 
       if (
         enabledInJs &&

--- a/src/instructions/config-resolver.ts
+++ b/src/instructions/config-resolver.ts
@@ -199,7 +199,7 @@ export async function resolveActiveRules(
   );
 
   return [...ruleNames]
-    .filter((ruleName) => ruleName in ruleInstructions)
+    .filter((ruleName) => Object.hasOwn(ruleInstructions, ruleName))
     .flatMap((ruleName): ResolvedRule[] => {
       const jsRule = resolveFirstEnabledRuleConfig(
         ruleName,
@@ -216,9 +216,9 @@ export async function resolveActiveRules(
         return [];
       }
 
-      // Safe `!` because the prior `.filter(ruleName => ruleName in ruleInstructions)`
-      // guarantees the key exists at runtime. The assertion avoids an untestable
-      // guard that would degrade statement coverage.
+      // Safe `!` because the prior `Object.hasOwn` check guarantees the key
+      // exists at runtime. The assertion avoids an untestable guard that would
+      // degrade statement coverage.
       const instruction = ruleInstructions[ruleName]!;
 
       if (

--- a/src/instructions/config-resolver.ts
+++ b/src/instructions/config-resolver.ts
@@ -216,13 +216,10 @@ export async function resolveActiveRules(
         return [];
       }
 
-      // Guard required for `noUncheckedIndexedAccess` — the prior
-      // `.filter(ruleName => ruleName in ruleInstructions)` guarantees
-      // the key exists at runtime.
-      const instruction = ruleInstructions[ruleName];
-      if (!instruction) {
-        return [];
-      }
+      // Safe `!` because the prior `.filter(ruleName => ruleName in ruleInstructions)`
+      // guarantees the key exists at runtime. The assertion avoids an untestable
+      // guard that would degrade statement coverage.
+      const instruction = ruleInstructions[ruleName]!;
 
       if (
         enabledInJs &&

--- a/src/rules/filename-match-export.ts
+++ b/src/rules/filename-match-export.ts
@@ -215,7 +215,9 @@ export default createRule<[], MessageIds>({
       "Program:exit"() {
         if (exportedNames.length !== 1) return;
 
-        const { name: exportName, node: exportNode } = exportedNames[0];
+        const exportedEntry = exportedNames[0];
+        if (!exportedEntry) return;
+        const { name: exportName, node: exportNode } = exportedEntry;
 
         if (filenameMatchesExport(filename, exportName)) return;
 

--- a/src/rules/max-complexity.ts
+++ b/src/rules/max-complexity.ts
@@ -138,9 +138,7 @@ export default createRule<Options, MessageIds>({
           key.expressions.length === 0 &&
           key.quasis.length === 1
         ) {
-          const quasi = key.quasis[0];
-          if (!quasi) return null;
-          return quasi.value.cooked;
+          return key.quasis[0]!.value.cooked;
         }
         // Dynamic computed key: { [expr]() {} }
         return null;

--- a/src/rules/max-complexity.ts
+++ b/src/rules/max-complexity.ts
@@ -138,7 +138,9 @@ export default createRule<Options, MessageIds>({
           key.expressions.length === 0 &&
           key.quasis.length === 1
         ) {
-          return key.quasis[0].value.cooked;
+          const quasi = key.quasis[0];
+          if (!quasi) return null;
+          return quasi.value.cooked;
         }
         // Dynamic computed key: { [expr]() {} }
         return null;

--- a/src/rules/no-commented-out-code.ts
+++ b/src/rules/no-commented-out-code.ts
@@ -82,7 +82,7 @@ export default createRule<[], MessageIds>({
         const processed = new Set<(typeof comments)[number]>();
 
         for (let i = 0; i < comments.length; i++) {
-          const comment = comments[i];
+          const comment = comments[i]!;
           if (processed.has(comment)) continue;
           processed.add(comment);
 
@@ -103,7 +103,8 @@ export default createRule<[], MessageIds>({
             let j = i + 1;
             while (j < comments.length) {
               const next = comments[j];
-              const prev = group[group.length - 1];
+              if (!next) break;
+              const prev = group[group.length - 1]!;
               if (
                 next.type === "Line" &&
                 next.loc.start.line === prev.loc.end.line + 1
@@ -118,10 +119,12 @@ export default createRule<[], MessageIds>({
 
             const groupText = group.map((c) => c.value).join("\n");
             if (containsCode(groupText)) {
+              const firstLoc = group[0]!.loc;
+              const lastLoc = group[group.length - 1]!.loc;
               context.report({
                 loc: {
-                  start: group[0].loc.start,
-                  end: group[group.length - 1].loc.end,
+                  start: firstLoc.start,
+                  end: lastLoc.end,
                 },
                 messageId: "noCommentedOutCode",
               });

--- a/src/rules/no-incorrect-sort.ts
+++ b/src/rules/no-incorrect-sort.ts
@@ -84,7 +84,7 @@ export default createRule<[], MessageIds>({
           return;
         }
 
-        const [firstArg] = args;
+        const firstArg = args[0]!;
         if (
           firstArg.type === AST_NODE_TYPES.Identifier &&
           firstArg.name === "undefined"

--- a/src/rules/no-inline-disable.ts
+++ b/src/rules/no-inline-disable.ts
@@ -43,7 +43,7 @@ export default createRule<[], MessageIds>({
           loc: comment.loc,
           messageId: "noInlineDisable",
           data: {
-            comment: `// ${value.split("\n")[0].trim()}`,
+            comment: `// ${value.split("\n")[0]!.trim()}`,
           },
         });
       }

--- a/src/rules/no-llm-artifacts.ts
+++ b/src/rules/no-llm-artifacts.ts
@@ -98,7 +98,7 @@ export default createRule<[], MessageIds>({
 
     function checkFunctionBody(body: TSESTree.BlockStatement): void {
       if (body.body.length !== 1) return;
-      const stmt = body.body[0];
+      const stmt = body.body[0]!;
       // throw new Error("not implemented") as sole statement
       if (isNotImplementedThrow(stmt)) {
         context.report({

--- a/src/rules/no-redundant-logic.ts
+++ b/src/rules/no-redundant-logic.ts
@@ -58,7 +58,7 @@ function alternateIsSimple(alternate: TSESTree.Statement): boolean {
   if (
     alternate.type === AST_NODE_TYPES.BlockStatement &&
     alternate.body.length === 1 &&
-    isReturnOrThrow(alternate.body[0])
+    isReturnOrThrow(alternate.body[0]!)
   ) {
     return true;
   }
@@ -216,7 +216,7 @@ export default createRule<[], MessageIds>({
           {
             messageId: "unnecessaryElseSuggest",
             fix(fixer) {
-              const line = sourceCode.lines[node.loc.start.line - 1];
+              const line = sourceCode.lines[node.loc.start.line - 1] ?? "";
               const leadingWhitespace = line.match(/^\s*/)?.[0] ?? "";
               const ifIndent =
                 leadingWhitespace.length >= node.loc.start.column
@@ -227,7 +227,7 @@ export default createRule<[], MessageIds>({
 
               let innerText: string;
               if (alternate.type === AST_NODE_TYPES.BlockStatement) {
-                innerText = sourceCode.getText(alternate.body[0]);
+                innerText = sourceCode.getText(alternate.body[0]!);
               } else {
                 innerText = sourceCode.getText(alternate);
               }
@@ -291,7 +291,7 @@ export default createRule<[], MessageIds>({
         branch.type === AST_NODE_TYPES.BlockStatement &&
         branch.body.length === 1
       ) {
-        return branch.body[0];
+        return branch.body[0] ?? null;
       }
       if (branch.type !== AST_NODE_TYPES.BlockStatement) return branch;
       return null;

--- a/src/rules/prefer-early-return.ts
+++ b/src/rules/prefer-early-return.ts
@@ -25,7 +25,7 @@ function isShortElse(alternate: TSESTree.Statement): boolean {
   if (
     alternate.type === AST_NODE_TYPES.BlockStatement &&
     alternate.body.length === 1 &&
-    isReturnOrThrow(alternate.body[0])
+    isReturnOrThrow(alternate.body[0]!)
   ) {
     return true;
   }
@@ -106,7 +106,7 @@ export default createRule<Options, MessageIds>({
       // Function body must have exactly one statement
       if (body.body.length !== 1) return;
 
-      const onlyStatement = body.body[0];
+      const onlyStatement = body.body[0]!;
       if (onlyStatement.type !== AST_NODE_TYPES.IfStatement) return;
 
       const ifStatement = onlyStatement;

--- a/src/rules/structured-logging.ts
+++ b/src/rules/structured-logging.ts
@@ -116,7 +116,7 @@ export default createRule<Options, MessageIds>({
     ): TSESTree.Node | null {
       if (node.arguments.length === 0) return null;
 
-      const firstArg = node.arguments[0];
+      const firstArg = node.arguments[0]!;
 
       // For logException(error, message, ...) patterns, check second arg
       // if first arg is an identifier (the error object)
@@ -126,7 +126,7 @@ export default createRule<Options, MessageIds>({
         callee.name === "logException" &&
         node.arguments.length >= 2
       ) {
-        return node.arguments[1];
+        return node.arguments[1]!;
       }
 
       return firstArg;

--- a/src/rules/uninvoked-array-callback.ts
+++ b/src/rules/uninvoked-array-callback.ts
@@ -64,20 +64,24 @@ function isSingleLengthArrayArgument(
 
 function isSparseArrayConstructorCall(node: TSESTree.Node): boolean {
   if (node.type === AST_NODE_TYPES.NewExpression) {
+    const firstArg = node.arguments[0];
     return (
       node.callee.type === AST_NODE_TYPES.Identifier &&
       node.callee.name === "Array" &&
       node.arguments.length === 1 &&
-      isSingleLengthArrayArgument(node.arguments[0])
+      firstArg !== undefined &&
+      isSingleLengthArrayArgument(firstArg)
     );
   }
 
   if (node.type === AST_NODE_TYPES.CallExpression) {
+    const firstArg = node.arguments[0];
     return (
       node.callee.type === AST_NODE_TYPES.Identifier &&
       node.callee.name === "Array" &&
       node.arguments.length === 1 &&
-      isSingleLengthArrayArgument(node.arguments[0])
+      firstArg !== undefined &&
+      isSingleLengthArrayArgument(firstArg)
     );
   }
 

--- a/src/rules/uninvoked-array-callback.ts
+++ b/src/rules/uninvoked-array-callback.ts
@@ -64,24 +64,20 @@ function isSingleLengthArrayArgument(
 
 function isSparseArrayConstructorCall(node: TSESTree.Node): boolean {
   if (node.type === AST_NODE_TYPES.NewExpression) {
-    const firstArg = node.arguments[0];
     return (
       node.callee.type === AST_NODE_TYPES.Identifier &&
       node.callee.name === "Array" &&
       node.arguments.length === 1 &&
-      firstArg !== undefined &&
-      isSingleLengthArrayArgument(firstArg)
+      isSingleLengthArrayArgument(node.arguments[0]!)
     );
   }
 
   if (node.type === AST_NODE_TYPES.CallExpression) {
-    const firstArg = node.arguments[0];
     return (
       node.callee.type === AST_NODE_TYPES.Identifier &&
       node.callee.name === "Array" &&
       node.arguments.length === 1 &&
-      firstArg !== undefined &&
-      isSingleLengthArrayArgument(firstArg)
+      isSingleLengthArrayArgument(node.arguments[0]!)
     );
   }
 


### PR DESCRIPTION
## What

Implements #189 — MCP server v2 zero-config fallback. Adds an opt-in transient fallback ESLint configuration for repos without a discoverable ESLint config.

### Behavior

- **Project config present**: `lint_file` uses it exactly as v1, results labeled `source: "project-config"`.
- **No config + fallback disabled**: returns existing setup/install guidance.
- **No config + fallback enabled** (`LLM_CORE_MCP_ENABLE_FALLBACK=1`): runs a transient read-only `llm-core` recommended config with TypeScript parser, results labeled `source: "fallback"`.

### What changed

| File | Change |
|------|--------|
| `packages/mcp-server/src/tools/lint-file.ts` | Fallback config, source labeling, structured response metadata, `newFlatESLint` helper |
| `packages/mcp-server/src/server.ts` | Env parsing for `LLM_CORE_MCP_ENABLE_FALLBACK` |
| `packages/mcp-server/tests/lint-file.test.ts` | 16 tests covering precedence, fallback, TS parsing, sandboxing, no mutation |
| `packages/mcp-server/tests/server.test.ts` | Env parsing test |
| `packages/mcp-server/README.md` | Fallback setup docs + tradeoffs |
| `README.md` | Fallback setup docs |
| `.changeset/mcp-zero-config-fallback.md` | Minor bumps for both packages |

### Fixes included

Pre-existing TypeScript strict build errors across 12 core files (`exactOptionalPropertyTypes`, `noUncheckedIndexedAccess`). The full build now passes.

## Verification

- [x] `npm run build` — passes
- [x] `npm run test` — 916 tests pass (884 core + 32 MCP)
- [x] `npm run lint` — passes
- [x] `npm run format:check` — passes

Closes #189

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional zero-config fallback mode for MCP linting when a project ESLint config isn’t found, enabled with `LLM_CORE_MCP_ENABLE_FALLBACK=1`.
  * Lint results now indicate whether findings came from the project config or the fallback mode.

* **Documentation**
  * Updated MCP server docs to explain config discovery, fallback behavior, and read-only limitations.

* **Tests**
  * Expanded coverage for fallback behavior, config precedence, filesystem safety, and environment-based enablement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->