### PR TITLE
fix: include violation details in structuredContent for MCP clients

### DIFF
--- a/.changeset/mcp-structuredContent-violations.md
+++ b/.changeset/mcp-structuredContent-violations.md
@@ -1,0 +1,7 @@
+---
+"eslint-plugin-llm-core-mcp": patch
+---
+
+Include full violation details in MCP lint_file `structuredContent` so clients
+that prefer structured responses over text content see the individual
+what/why/how-to-fix messages alongside the violation count.

--- a/packages/mcp-server/src/tools/lint-file.ts
+++ b/packages/mcp-server/src/tools/lint-file.ts
@@ -435,6 +435,7 @@ export function registerLintFile(
               structuredContent: {
                 source,
                 violationCount: violations.length,
+                violations,
               },
               content: [
                 {
@@ -459,6 +460,7 @@ export function registerLintFile(
         structuredContent: {
           source,
           violationCount: violations.length,
+          violations,
         },
         content: [
           { type: "text" as const, text: JSON.stringify(violations, null, 2) },

--- a/packages/mcp-server/tests/lint-file.test.ts
+++ b/packages/mcp-server/tests/lint-file.test.ts
@@ -113,9 +113,17 @@ describe("lint_file tool", () => {
     expect(typeof violation?.message).toBe("string");
     expect(violation?.message.length).toBeGreaterThan(0);
     expect(violation?.source).toBe("project-config");
-    expect((result as LintToolResult).structuredContent).toMatchObject({
+    const sc = (result as LintToolResult).structuredContent!;
+    expect(sc).toMatchObject({
       source: "project-config",
       violationCount: violations.length,
+    });
+    expect(sc.violations).toHaveLength(violations.length);
+    expect(sc.violations![0] as LintViolation).toMatchObject({
+      ruleId: "llm-core/no-empty-catch",
+      severity: 2,
+      instruction:
+        "Never leave catch blocks empty — handle, rethrow, or log the error",
     });
     // Instruction must be attached and carry the rule's guidance verbatim.
     expect(violation?.instruction).toBe(
@@ -267,6 +275,17 @@ describe("lint_file with no discoverable ESLint config", () => {
         source: "fallback",
         violationCount: violations.length,
       });
+      expect(result.structuredContent!.violations).toHaveLength(
+        violations.length,
+      );
+      expect(
+        result.structuredContent!.violations![0] as LintViolation,
+      ).toMatchObject({
+        ruleId: "llm-core/no-empty-catch",
+        source: "fallback",
+        instruction:
+          "Never leave catch blocks empty — handle, rethrow, or log the error",
+      });
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
@@ -288,6 +307,7 @@ describe("lint_file with no discoverable ESLint config", () => {
       source: "project-config",
       violationCount: 0,
     });
+    expect(result.structuredContent!.violations).toEqual([]);
   });
 
   it("parses TypeScript syntax in fallback mode", async () => {

--- a/packages/mcp-server/tests/lint-file.test.ts
+++ b/packages/mcp-server/tests/lint-file.test.ts
@@ -34,6 +34,7 @@ interface LintToolResult {
   structuredContent?: {
     source?: unknown;
     violationCount?: unknown;
+    violations?: unknown[];
   };
 }
 
@@ -112,7 +113,7 @@ describe("lint_file tool", () => {
     expect(typeof violation?.message).toBe("string");
     expect(violation?.message.length).toBeGreaterThan(0);
     expect(violation?.source).toBe("project-config");
-    expect((result as LintToolResult).structuredContent).toEqual({
+    expect((result as LintToolResult).structuredContent).toMatchObject({
       source: "project-config",
       violationCount: violations.length,
     });
@@ -262,7 +263,7 @@ describe("lint_file with no discoverable ESLint config", () => {
             "Never leave catch blocks empty — handle, rethrow, or log the error",
         }),
       );
-      expect(result.structuredContent).toEqual({
+      expect(result.structuredContent).toMatchObject({
         source: "fallback",
         violationCount: violations.length,
       });
@@ -283,7 +284,7 @@ describe("lint_file with no discoverable ESLint config", () => {
     })) as LintToolResult;
 
     expect(readViolations(result)).toEqual([]);
-    expect(result.structuredContent).toEqual({
+    expect(result.structuredContent).toMatchObject({
       source: "project-config",
       violationCount: 0,
     });


### PR DESCRIPTION
## What

MCP clients that prefer `structuredContent` over `content` were only seeing `{ source, violationCount }` without the individual violation what/why/how-to-fix messages.

### Fix

Added the full `violations` array to `structuredContent` on both response paths (project-config and fallback) so all MCP clients receive the complete guidance regardless of which response field they consume.

### Changes

- `packages/mcp-server/src/tools/lint-file.ts` — added `violations` to both `structuredContent` return objects
- `packages/mcp-server/tests/lint-file.test.ts` — updated `LintToolResult` interface and switched assertions to `toMatchObject`
- `.changeset/mcp-structuredContent-violations.md` — patch changeset for MCP package

## Verification

- [x] `npm --workspace eslint-plugin-llm-core-mcp test` — 33 tests pass
- [x] `npm test` — 884 core tests pass
- [x] `npm run lint` — passes
- [x] `npm run format:check` — passes
- [x] `npm run test:coverage` — 93.16% (above 93% threshold)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Lint results now include full violation details in structured responses, not just the total count.
  * This applies whether linting uses the normal project configuration or a fallback response.
  * Clients that consume structured output can now show the same detailed messages that were previously only available in text form.

* **Documentation**
  * Updated release notes to reflect the improved structured lint output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->