### PR TITLE
Improve quality CLI compact and Knip scans

### DIFF
--- a/.changeset/smart-knip-quality.md
+++ b/.changeset/smart-knip-quality.md
@@ -1,0 +1,9 @@
+---
+"llm-core-quality": patch
+---
+
+Improve quality scan output and Knip execution defaults.
+
+- Hide verbose `llm-core/*` rule details in compact text output while preserving rule IDs and locations.
+- Show actionable Knip finding messages by category, such as unused files and dependencies.
+- Run Knip with `--cache` by default and add an optional `--production` flag for production-only Knip scans.

--- a/packages/quality-cli/README.md
+++ b/packages/quality-cli/README.md
@@ -64,7 +64,8 @@ llm-core-quality ci --json --compact
 | -------------------- | -------------------------------------------------------------------- |
 | `--json`             | Print normalized JSON output.                                        |
 | `--sarif`            | Print SARIF 2.1.0 output for code-scanning integrations.             |
-| `--compact`          | Print compact JSON/SARIF instead of pretty-printed output.           |
+| `--compact`          | Print compact output; text hides llm-core rule details.              |
+| `--production`       | Run Knip in production mode, excluding tests and dev-only code.      |
 | `--engine <engine>`  | Limit engines. Repeat or comma-separate `eslint` and `knip`.         |
 | `--fail-on-findings` | Exit non-zero when findings are present.                             |
 | `--no-exit-code`     | Exit zero for findings while still failing on tool execution errors. |

--- a/packages/quality-cli/src/cli-args.ts
+++ b/packages/quality-cli/src/cli-args.ts
@@ -32,6 +32,7 @@ export function parseCliArgs(args: string[], cwd = process.cwd()): ParsedCli {
   let failOnFindings = commandArg === "ci";
   let compact = false;
   let color: QualityScanOptions["color"] = "auto";
+  let production = false;
 
   for (let index = 0; index < rest.length; index += 1) {
     const arg = rest[index];
@@ -58,6 +59,11 @@ export function parseCliArgs(args: string[], cwd = process.cwd()): ParsedCli {
 
     if (arg === "--color") {
       color = "always";
+      continue;
+    }
+
+    if (arg === "--production") {
+      production = true;
       continue;
     }
 
@@ -110,6 +116,7 @@ export function parseCliArgs(args: string[], cwd = process.cwd()): ParsedCli {
       failOnFindings,
       compact,
       color,
+      production,
     },
   };
 }
@@ -138,7 +145,8 @@ Commands:
 Options:
   --json              Print normalized JSON.
   --sarif             Print SARIF 2.1.0.
-  --compact           Print compact JSON/SARIF instead of pretty output.
+  --compact           Print compact output; text hides llm-core rule details.
+  --production        Run Knip in production mode, excluding tests and dev-only code.
   --engine <engine>   Limit engines. Repeat or comma-separate: eslint,knip.
   --fail-on-findings  Exit non-zero when findings are present.
   --no-exit-code      Always exit zero unless a tool execution fails.

--- a/packages/quality-cli/src/cli.ts
+++ b/packages/quality-cli/src/cli.ts
@@ -26,6 +26,7 @@ async function main(): Promise<void> {
           : `${formatTextReport(result, {
               cwd: parsed.options.cwd,
               color: shouldUseColor(parsed.options),
+              compact: parsed.options.compact,
             })}\n`;
 
     process.stdout.write(output);

--- a/packages/quality-cli/src/reporters.ts
+++ b/packages/quality-cli/src/reporters.ts
@@ -12,6 +12,7 @@ import type {
 export type TextReportOptions = {
   cwd?: string;
   color?: boolean;
+  compact?: boolean;
 };
 
 export type MachineReportOptions = {
@@ -38,7 +39,11 @@ export function formatTextReport(
 
   if (result.findings.length > 0) {
     lines.push("");
-    lines.push(...formatFindingGroups(result.findings, options.cwd, colors));
+    lines.push(
+      ...formatFindingGroups(result.findings, options.cwd, colors, {
+        compact: options.compact ?? false,
+      }),
+    );
   }
 
   lines.push("");
@@ -65,6 +70,7 @@ function formatFindingGroups(
   findings: QualityFinding[],
   cwd: string | undefined,
   colors: ReturnType<typeof createColors>,
+  options: { compact: boolean },
 ): string[] {
   const lines: string[] = [];
   const maxRuleLength = Math.min(32, Math.max(...findings.map(ruleIdLength)));
@@ -77,8 +83,9 @@ function formatFindingGroups(
       const severity = colorSeverity(finding.severity.padEnd(7), colors);
       const rule = formatRuleColumn(finding, maxRuleLength);
       const location = formatLineColumn(finding);
+      const message = formatFindingMessage(finding, options);
       lines.push(
-        `  ${severity}  ${colors.cyan(rule)}  ${finding.message}${location ? `  ${colors.dim(location)}` : ""}`,
+        `  ${severity}  ${colors.cyan(rule)}${message ? `  ${message}` : ""}${location ? `  ${colors.dim(location)}` : ""}`,
       );
     }
 
@@ -188,6 +195,21 @@ function colorSeverity(
   }
 
   return colors.cyan(severity);
+}
+
+function formatFindingMessage(
+  finding: QualityFinding,
+  options: { compact: boolean },
+): string {
+  if (options.compact && isLlmCoreRule(finding)) {
+    return "";
+  }
+
+  return finding.message;
+}
+
+function isLlmCoreRule(finding: QualityFinding): boolean {
+  return finding.ruleId?.startsWith("llm-core/") ?? false;
 }
 
 function formatRuleColumn(

--- a/packages/quality-cli/src/runner.ts
+++ b/packages/quality-cli/src/runner.ts
@@ -17,13 +17,20 @@ export const DEFAULT_ENGINES: QualityEngine[] = ["eslint", "knip"];
 export function buildEngineArgs(
   engine: QualityEngine,
   targets: string[],
+  options: { production?: boolean } = {},
 ): string[] {
   if (engine === "eslint") {
     const eslintTargets = targets.length > 0 ? targets : ["."];
     return [...eslintTargets, "--format", "json"];
   }
 
-  return ["--reporter", "json", "--no-exit-code"];
+  return [
+    "--reporter",
+    "json",
+    "--no-exit-code",
+    "--cache",
+    ...(options.production ? ["--production"] : []),
+  ];
 }
 
 export function buildEngineCommand(engine: QualityEngine): string {
@@ -84,7 +91,9 @@ export async function runQualityScan(
     const invocation = await executor(
       engine,
       buildEngineCommand(engine),
-      buildEngineArgs(engine, options.targets),
+      buildEngineArgs(engine, options.targets, {
+        production: options.production,
+      }),
       options.cwd,
     );
     invocations.push(invocation);
@@ -160,7 +169,31 @@ function extractEslintFindings(stdout: string): QualityFinding[] {
   );
 }
 
-type KnipIssue = {
+type KnipIssueCategory =
+  | "binaries"
+  | "catalog"
+  | "dependencies"
+  | "devDependencies"
+  | "duplicates"
+  | "enumMembers"
+  | "exports"
+  | "files"
+  | "namespaceMembers"
+  | "optionalPeerDependencies"
+  | "types"
+  | "unlisted"
+  | "unresolved";
+
+type KnipIssueItem = {
+  name?: string;
+  symbol?: string;
+  file?: string;
+  filePath?: string;
+  line?: number;
+  col?: number;
+};
+
+type KnipIssue = Partial<Record<KnipIssueCategory, KnipIssueItem[]>> & {
   type?: string;
   file?: string;
   filePath?: string;
@@ -173,22 +206,95 @@ type KnipReport = {
   issues?: KnipIssue[];
 };
 
+const KNIP_CATEGORY_LABELS: Record<KnipIssueCategory, string> = {
+  binaries: "Unused binary",
+  catalog: "Unused catalog entry",
+  dependencies: "Unused dependency",
+  devDependencies: "Unused dev dependency",
+  duplicates: "Duplicate dependency",
+  enumMembers: "Unused enum member",
+  exports: "Unused export",
+  files: "Unused file",
+  namespaceMembers: "Unused namespace member",
+  optionalPeerDependencies: "Unused optional peer dependency",
+  types: "Unused type",
+  unlisted: "Unlisted dependency",
+  unresolved: "Unresolved dependency",
+};
+
+const KNIP_CATEGORIES = Object.keys(
+  KNIP_CATEGORY_LABELS,
+) as KnipIssueCategory[];
+
 function extractKnipFindings(stdout: string): QualityFinding[] {
   const parsed = parseJson<KnipReport>(stdout, {});
   const issues = Array.isArray(parsed.issues) ? parsed.issues : [];
 
-  return issues.map((issue) => ({
-    engine: "knip" as const,
-    severity: "warning" as const,
-    message: issue.message ?? describeKnipIssue(issue),
-    filePath: issue.filePath ?? issue.file,
-    ruleId: issue.type,
-  }));
+  return issues.flatMap((issue) => {
+    const findings = KNIP_CATEGORIES.flatMap((category) =>
+      describeKnipCategoryFindings(issue, category),
+    );
+
+    if (findings.length > 0) {
+      return findings;
+    }
+
+    return [describeLegacyKnipIssue(issue)];
+  });
 }
 
-function describeKnipIssue(issue: KnipIssue): string {
+function describeKnipCategoryFindings(
+  issue: KnipIssue,
+  category: KnipIssueCategory,
+): QualityFinding[] {
+  const items = issue[category];
+
+  if (!Array.isArray(items) || items.length === 0) {
+    return [];
+  }
+
+  return items.map((item) => {
+    const label = KNIP_CATEGORY_LABELS[category];
+    const name = describeKnipItemName(item, issue);
+
+    return {
+      engine: "knip" as const,
+      severity: "warning" as const,
+      message: `${label}: ${name}`,
+      filePath: item.filePath ?? item.file ?? issue.filePath ?? issue.file,
+      ruleId: category,
+      line: item.line,
+      column: item.col,
+    };
+  });
+}
+
+function describeLegacyKnipIssue(issue: KnipIssue): QualityFinding {
   const label = issue.symbol ?? issue.name ?? issue.file ?? "project issue";
-  return issue.type ? `${issue.type}: ${label}` : `Knip reported ${label}`;
+
+  return {
+    engine: "knip" as const,
+    severity: "warning" as const,
+    message:
+      issue.message ??
+      (issue.type ? `${issue.type}: ${label}` : `Knip reported ${label}`),
+    filePath: issue.filePath ?? issue.file,
+    ruleId: issue.type,
+  };
+}
+
+function describeKnipItemName(item: KnipIssueItem, issue: KnipIssue): string {
+  return (
+    item.symbol ??
+    item.name ??
+    item.filePath ??
+    item.file ??
+    issue.symbol ??
+    issue.name ??
+    issue.filePath ??
+    issue.file ??
+    "project issue"
+  );
 }
 
 function toSeverity(severity: number | undefined): QualitySeverity {

--- a/packages/quality-cli/src/types.ts
+++ b/packages/quality-cli/src/types.ts
@@ -36,6 +36,7 @@ export type QualityScanOptions = {
   failOnFindings: boolean;
   compact: boolean;
   color: QualityColorMode;
+  production: boolean;
 };
 
 export type QualityScanResult = {

--- a/packages/quality-cli/tests/cli-args.test.ts
+++ b/packages/quality-cli/tests/cli-args.test.ts
@@ -17,6 +17,7 @@ describe("parseCliArgs", () => {
         failOnFindings: false,
         compact: false,
         color: "auto",
+        production: false,
       },
     });
   });
@@ -38,7 +39,15 @@ describe("parseCliArgs", () => {
         failOnFindings: true,
         compact: false,
         color: "auto",
+        production: false,
       },
+    });
+  });
+
+  it("parses production mode", () => {
+    expect(parseCliArgs(["scan", "--production"], "/repo")).toMatchObject({
+      kind: "run",
+      options: { production: true },
     });
   });
 
@@ -54,6 +63,7 @@ describe("parseCliArgs", () => {
         failOnFindings: false,
         compact: true,
         color: "auto",
+        production: false,
       },
     });
 
@@ -82,6 +92,7 @@ describe("parseCliArgs", () => {
         failOnFindings: false,
         compact: false,
         color: "auto",
+        production: false,
       },
     });
   });

--- a/packages/quality-cli/tests/color.test.ts
+++ b/packages/quality-cli/tests/color.test.ts
@@ -61,5 +61,6 @@ function optionsWithColor(
     engines: ["eslint"],
     failOnFindings: false,
     compact: false,
+    production: false,
   };
 }

--- a/packages/quality-cli/tests/reporters.test.ts
+++ b/packages/quality-cli/tests/reporters.test.ts
@@ -50,7 +50,7 @@ const RESULT_WITH_FINDINGS: QualityScanResult = {
 
 const formatText = formatTextReport as (
   result: QualityScanResult,
-  options?: { cwd?: string; color?: boolean },
+  options?: { cwd?: string; color?: boolean; compact?: boolean },
 ) => string;
 const formatJson = formatJsonReport as (
   result: QualityScanResult,
@@ -85,6 +85,55 @@ describe("reporters", () => {
     expect(output).toContain("errors:   1");
     expect(output).toContain("warnings: 1");
     expect(output).toContain("status:   fail");
+  });
+
+  it("omits llm-core rule detail in compact text output", () => {
+    const output = formatText(
+      {
+        ok: false,
+        exitCode: 1,
+        findings: [
+          {
+            engine: "eslint",
+            severity: "error",
+            message:
+              "What: Promise.all is unbounded.\n\nWhy: Large inputs can exhaust memory.\n\nHow to fix: Limit concurrency.",
+            filePath: "/repo/src/index.ts",
+            ruleId: "llm-core/no-unbounded-promise-all",
+            line: 12,
+            column: 5,
+          },
+          {
+            engine: "eslint",
+            severity: "error",
+            message: "Unexpected any",
+            filePath: "/repo/src/index.ts",
+            ruleId: "@typescript-eslint/no-explicit-any",
+            line: 20,
+            column: 10,
+          },
+        ],
+        invocations: [
+          {
+            engine: "eslint",
+            command: "eslint",
+            args: [],
+            exitCode: 1,
+            stdout: "[]",
+            stderr: "",
+          },
+        ],
+      },
+      { cwd: "/repo", color: false, compact: true },
+    );
+
+    expect(output).toContain("llm-core/no-unbounded-promise-a…  12:5");
+    expect(output).not.toContain("What: Promise.all is unbounded");
+    expect(output).not.toContain("Why: Large inputs can exhaust memory");
+    expect(output).not.toContain("How to fix: Limit concurrency");
+    expect(output).toContain(
+      "@typescript-eslint/no-explicit-…  Unexpected any  20:10",
+    );
   });
 
   it("colors text output only when enabled", () => {

--- a/packages/quality-cli/tests/run-quality-scan.test.ts
+++ b/packages/quality-cli/tests/run-quality-scan.test.ts
@@ -33,6 +33,7 @@ describe("runQualityScan", () => {
         failOnFindings: true,
         compact: false,
         color: "auto",
+        production: false,
       },
       fakeExecutor(),
     );
@@ -49,6 +50,33 @@ describe("runQualityScan", () => {
       "--reporter",
       "json",
       "--no-exit-code",
+      "--cache",
+    ]);
+  });
+
+  it("passes production mode to Knip only", async () => {
+    const result = await runQualityScan(
+      {
+        command: "scan",
+        reporter: "json",
+        cwd: "/repo",
+        targets: ["src"],
+        engines: ["eslint", "knip"],
+        failOnFindings: false,
+        compact: false,
+        color: "auto",
+        production: true,
+      },
+      fakeExecutor(),
+    );
+
+    expect(result.invocations[0]?.args).toEqual(["src", "--format", "json"]);
+    expect(result.invocations[1]?.args).toEqual([
+      "--reporter",
+      "json",
+      "--no-exit-code",
+      "--cache",
+      "--production",
     ]);
   });
 
@@ -63,6 +91,7 @@ describe("runQualityScan", () => {
         failOnFindings: true,
         compact: false,
         color: "auto",
+        production: false,
       },
       fakeExecutor(
         { eslint: 1 },
@@ -100,6 +129,58 @@ describe("runQualityScan", () => {
     ]);
   });
 
+  it("describes Knip category findings with actionable item names", async () => {
+    const result = await runQualityScan(
+      {
+        command: "scan",
+        reporter: "text",
+        cwd: "/repo",
+        targets: [],
+        engines: ["knip"],
+        failOnFindings: false,
+        compact: false,
+        color: "auto",
+        production: false,
+      },
+      fakeExecutor(
+        { knip: 1 },
+        {
+          knip: JSON.stringify({
+            issues: [
+              {
+                file: "src/unused.ts",
+                files: [{ name: "src/unused.ts" }],
+              },
+              {
+                file: "package.json",
+                dependencies: [{ name: "lodash", line: 12, col: 6 }],
+              },
+            ],
+          }),
+        },
+      ),
+    );
+
+    expect(result.findings).toEqual([
+      {
+        engine: "knip",
+        severity: "warning",
+        message: "Unused file: src/unused.ts",
+        filePath: "src/unused.ts",
+        ruleId: "files",
+      },
+      {
+        engine: "knip",
+        severity: "warning",
+        message: "Unused dependency: lodash",
+        filePath: "package.json",
+        ruleId: "dependencies",
+        line: 12,
+        column: 6,
+      },
+    ]);
+  });
+
   it("fails on tool execution errors even when findings are allowed", async () => {
     const result = await runQualityScan(
       {
@@ -111,6 +192,7 @@ describe("runQualityScan", () => {
         failOnFindings: false,
         compact: false,
         color: "auto",
+        production: false,
       },
       fakeExecutor({ eslint: 2 }),
     );


### PR DESCRIPTION
## What does this PR do?

Improves `llm-core-quality` scan output and Knip execution behavior.

- Hides verbose `llm-core/*` rule details in compact text output while preserving rule IDs and locations.
- Converts Knip category output into actionable findings, such as unused files and dependencies.
- Runs Knip with `--cache` by default and adds `--production` as an optional user flag.
- Adds a patch changeset for `llm-core-quality`.

## Verification

### Functional

✅ Hit: compact text output for `llm-core/no-unbounded-promise-all` keeps the rule/location and omits the verbose `What/Why/How to fix` details.

✅ Hit: Knip JSON category entries such as `files` and `dependencies` become actionable text findings like `Unused file: src/unused.ts` and `Unused dependency: lodash`.

✅ Hit: `--production` parses to `production: true` and Knip args become `--reporter json --no-exit-code --cache --production`.

✅ Clean: non-llm-core ESLint messages still show in compact text output.

✅ Clean: ESLint args remain target + `--format json`; default Knip args include `--cache` but not `--production`.

### Tests

- `npm --workspace llm-core-quality test` — 24 tests passed
- `npm run build:quality` — passed
- `npm run lint` — passed
- `node packages/quality-cli/dist/cli.js --help | grep -E -- '--production|--compact'` — confirmed help text includes both flags
- `git diff --check` — clean

### Contract

- [x] `QualityScanOptions` includes explicit `production: boolean`
- [x] CLI parser accepts `--production`
- [x] Runner applies `--production` only to Knip
- [x] `buildEngineArgs` remains backward-compatible through an optional third parameter
- [x] CLI help and README document the new option

### Docs

- [x] `packages/quality-cli/README.md` updated
- [x] Changeset added for `llm-core-quality`

## Checklist

- [x] `npm run build` passes (package-scoped: `npm run build:quality`)
- [x] `npm run test` passes (package-scoped: `npm --workspace llm-core-quality test`; new tests added)
- [x] `npm run lint` passes
- [x] `npm run update:eslint-docs` ran (N/A — no ESLint rules were added or changed)
- [x] Docs added/updated (N/A for rule docs; quality CLI README updated)
- [x] Rule exported in `src/rules/index.ts` (N/A — no rule added)
- [x] Rule added to `recommendedRules` in `src/index.ts` (N/A — no rule added)

## Agent Disclosure (complete if this PR was authored by an AI agent)

**Agent:** OpenAI Codex via pi coding agent

**Instruction files loaded:**

- [ ] `.github/copilot-instructions.md` (not loaded; project instructions came from `AGENTS.md`)
- [ ] `.github/instructions/rule-implementation.md` (not applicable)
- [ ] `.github/instructions/rule-tests.md` (not applicable)
- [ ] `.github/instructions/rule-docs.md` (not applicable)
- [ ] `.github/instructions/plugin-config.md` (not applicable)
- [x] `AGENTS.md`
- [x] `.agents/directives/adaptive-routing.md`
- [x] `.agents/directives/codebase-navigation.md`
- [x] `.agents/directives/type-driven-development.md`
- [x] `.agents/directives/test-driven-development.md`
- [x] `.agents/directives/verification.md`
- [x] `.agents/directives/workspace-isolation.md`
- [x] `.agents/directives/architecture-boundaries.md`
- [x] `.agents/directives/agent-permissions.md`
- [x] `.agents/skills/test-reviewer/SKILL.md`
- [x] `.agents/skills/self-audit/SKILL.md`
- [x] `.agents/skills/systematic-debugging/SKILL.md`
- [x] `.agents/skills/architecture-boundary-reviewer/SKILL.md`
- [ ] `.agents/directives/ERROR_MEMORY.md` (not loaded; no recurring error-memory entry needed)
- [ ] `.agents/directives/SESSION_DECISIONS.md` (not loaded; no durable policy decision made)
- [x] If `SESSION_DECISIONS.md` was loaded **and** this PR set a durable repo/process or cross-cutting decision whose reasoning is not obvious from the diff, a `docs/decisions/YYYY-MM-DD-<topic>.md` entry is included in this PR (N/A)

**Instruction files NOT loaded (explain if unexpected):**

Scoped rule/plugin instruction files were not loaded because this PR touches the quality CLI, not ESLint rule implementation, rule tests, rule docs, or plugin config.
