### PR TITLE
fix: correct eval test import paths after workspace conversion

### DIFF
--- a/packages/eslint-plugin/tests/evals/code-diff.test.ts
+++ b/packages/eslint-plugin/tests/evals/code-diff.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { computeCodeDiff } from "../../evals/src/code-diff";
+import { computeCodeDiff } from "../../../../evals/src/code-diff";
 
 describe("computeCodeDiff", () => {
   it("produces a unified diff showing added and removed lines", () => {

--- a/packages/eslint-plugin/tests/evals/eval-loop.test.ts
+++ b/packages/eslint-plugin/tests/evals/eval-loop.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   collectExportedSymbolNames,
   preservesExportedApi,
-} from "../../evals/src/eval-loop";
+} from "../../../../evals/src/eval-loop";
 
 describe("eval fixture API preservation", () => {
   it("collects exported symbol names from function and const exports", () => {

--- a/packages/eslint-plugin/tests/evals/llm-client.test.ts
+++ b/packages/eslint-plugin/tests/evals/llm-client.test.ts
@@ -4,9 +4,9 @@ import {
   buildFixViolationsPrompt,
   extractReasoning,
   formatViolationList,
-} from "../../evals/src/llm-client";
-import { stripViolationMessages } from "../../evals/src/strip-messages";
-import type { LintViolation } from "../../evals/src/types";
+} from "../../../../evals/src/llm-client";
+import { stripViolationMessages } from "../../../../evals/src/strip-messages";
+import type { LintViolation } from "../../../../evals/src/types";
 
 const sampleViolations: LintViolation[] = [
   {

--- a/packages/eslint-plugin/tests/evals/patterns.test.ts
+++ b/packages/eslint-plugin/tests/evals/patterns.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { detectPatterns } from "../../evals/src/patterns";
-import type { IterationRecord } from "../../evals/src/types";
+import { detectPatterns } from "../../../../evals/src/patterns";
+import type { IterationRecord } from "../../../../evals/src/types";
 
 describe("detectPatterns", () => {
   it("identifies stuck rules that persist across all iterations", () => {

--- a/packages/eslint-plugin/tests/evals/query.test.ts
+++ b/packages/eslint-plugin/tests/evals/query.test.ts
@@ -3,8 +3,8 @@ import {
   queryByRule,
   queryUnresolved,
   queryStuckRules,
-} from "../../evals/src/query";
-import type { EvalResults, FixtureResult } from "../../evals/src/types";
+} from "../../../../evals/src/query";
+import type { EvalResults, FixtureResult } from "../../../../evals/src/types";
 
 function makeResult(
   overrides: Partial<FixtureResult> & Pick<FixtureResult, "fixture" | "mode">,

--- a/packages/eslint-plugin/tests/evals/replay.test.ts
+++ b/packages/eslint-plugin/tests/evals/replay.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { findIterationTrace, type ReplayTarget } from "../../evals/src/replay";
-import type { EvalResults } from "../../evals/src/types";
+import {
+  findIterationTrace,
+  type ReplayTarget,
+} from "../../../../evals/src/replay";
+import type { EvalResults } from "../../../../evals/src/types";
 
 const sampleResults: EvalResults = {
   date: "2026-04-08",

--- a/packages/eslint-plugin/tests/evals/reporter.test.ts
+++ b/packages/eslint-plugin/tests/evals/reporter.test.ts
@@ -4,8 +4,8 @@ import {
   generateHistoryLine,
   generateJson,
   generateMarkdown,
-} from "../../evals/src/reporter";
-import type { EvalResults } from "../../evals/src/types";
+} from "../../../../evals/src/reporter";
+import type { EvalResults } from "../../../../evals/src/types";
 
 describe("eval reporting", () => {
   it("includes remaining rule ids and rejection reasons in markdown details", () => {

--- a/packages/eslint-plugin/tests/evals/strip-messages.test.ts
+++ b/packages/eslint-plugin/tests/evals/strip-messages.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from "vitest";
 import {
   stripToFirstLine,
   stripViolationMessages,
-} from "../../evals/src/strip-messages";
-import type { LintViolation } from "../../evals/src/types";
+} from "../../../../evals/src/strip-messages";
+import type { LintViolation } from "../../../../evals/src/types";
 
 describe("strip-messages", () => {
   it("keeps the first line when a message has guidance sections", () => {

--- a/packages/eslint-plugin/tests/evals/violation-diff.test.ts
+++ b/packages/eslint-plugin/tests/evals/violation-diff.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { computeViolationDiff } from "../../evals/src/violation-diff";
-import type { LintViolation } from "../../evals/src/types";
+import { computeViolationDiff } from "../../../../evals/src/violation-diff";
+import type { LintViolation } from "../../../../evals/src/types";
 
 describe("computeViolationDiff", () => {
   it("categorizes violations as resolved, persisted, or introduced", () => {


### PR DESCRIPTION
## Summary
- The workspace conversion (`6747353`) moved eval test files from `tests/evals/` to `packages/eslint-plugin/tests/evals/` but left their relative imports pointing at `../../evals/src/*`, which now resolves to a non-existent `packages/eslint-plugin/evals/src` instead of the actual repo-root `evals/src` directory.
- Found via `npx fallow dead-code`, which flagged 29 `unresolved_imports`; confirmed by running the affected test files directly (`Cannot find module '../../evals/src/llm-client'`).
- Updated all 9 affected test files under `packages/eslint-plugin/tests/evals/` to `../../../../evals/src/*`.

## Test plan
- [x] `npx vitest run packages/eslint-plugin/tests/evals/` — 9 files, 40 tests passing
- [x] `npm run test:core` — 61 files, 1114 tests passing
- [x] `npm run lint` — clean
- [x] `npx fallow dead-code --format json` re-run — `unresolved_imports` dropped from 29 to 0 (total issues 64 → 22)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated evaluation test references to use the correct module locations.
  * Preserved all existing test cases, assertions, fixtures, and expected behavior.
  * Improved test reliability across code diffs, evaluation loops, reporting, replay, queries, and violation handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->