### PR TITLE
fix(ci): use npm 11 for deterministic installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
+      - name: Use npm 11
+        run: npm install --global npm@11.18.0
       - run: npm ci
       - run: npm run build
       - run: npm run lint

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -36,6 +36,9 @@ jobs:
           node-version: 22
           cache: npm
 
+      - name: Use npm 11
+        run: npm install --global npm@11.18.0
+
       - run: npm ci
 
       - name: Run evals

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,8 @@ jobs:
           node-version: 22
           registry-url: https://registry.npmjs.org
           cache: npm
+      - name: Use npm 11
+        run: npm install --global npm@11.18.0
       - run: npm ci
       - run: npm run build
       - run: npm run test


### PR DESCRIPTION
## What does this PR do?

Aligns all GitHub Actions dependency installs with npm 11.18.0 before `npm ci`.

Dependabot can generate a lockfile that npm 11 accepts but npm 10 rejects. The historical Dependabot snapshot from PR #321 fails under npm 10 with `Missing: conventional-commits-parser@6.4.0 from lock file`, so the CI job failed before build or tests. This keeps the Node 20/22 runtime matrix unchanged while using the same npm lockfile resolver behavior as Dependabot.

## Verification

### Functional

- ✅ Hit: npm 10.9.2 rejects the exact PR #321 snapshot with `EUSAGE` and the missing `conventional-commits-parser@6.4.0` lockfile entry.
- ✅ Clean: npm 11.18.0 installs both that snapshot and the current repository lockfile with `npm ci --ignore-scripts --dry-run`.
- ✅ Integration: all three workflows parse as YAML and invoke npm 11 before `npm ci`.

### Checks

- `npm run build`
- `npm run test`
- `npm run lint`
- `npm run format:check`
- `git diff --check`
- Prettier check for the modified workflows

### Scope control

Changed only `.github/workflows/ci.yml`, `.github/workflows/evals.yml`, and `.github/workflows/release.yml`. No production code, lockfile, package manifest, or dependency version changed.

## Checklist

- [x] `npm run build` passes
- [x] `npm run test` passes (new tests added if applicable; N/A — workflow-only change)
- [x] `npm run lint` passes
- [x] `npm run update:eslint-docs` ran (if rules were added or changed; N/A)
- [x] Docs added/updated (if adding a new rule; N/A)
- [x] Rule exported in `src/rules/index.ts` (if adding a new rule; N/A)
- [x] Rule added to `recommendedRules` in `src/index.ts` (if applicable; N/A)

## Agent Disclosure (complete if this PR was authored by an AI agent)

**Agent:** Codex

**Instruction files loaded:**

- [ ] `.github/copilot-instructions.md` (not applicable; file was not loaded)
- [ ] `.github/instructions/rule-implementation.md` (not applicable; no rule files changed)
- [ ] `.github/instructions/rule-tests.md` (not applicable; no rule test files changed)
- [ ] `.github/instructions/rule-docs.md` (not applicable; no rule docs changed)
- [ ] `.github/instructions/plugin-config.md` (not applicable; plugin config not changed)
- [x] `AGENTS.md`
- [x] `.agents/directives/TYPE_DRIVEN_DEVELOPMENT.md`
- [x] `.agents/directives/TEST_DRIVEN_DEVELOPMENT.md`
- [x] `.agents/directives/CODEBASE_NAVIGATION.md`
- [x] `.agents/directives/ERROR_MEMORY.md`
- [x] `.agents/directives/VERIFICATION.md`
- [ ] `.agents/directives/SESSION_DECISIONS.md` (not applicable; no durable repository/process decision beyond this localized CI repair)
- [x] No decision record required

**Instruction files NOT loaded (explain if unexpected):**

The rule-specific instructions were out of scope because this PR changes only GitHub Actions workflows. The Copilot instruction file and session-decisions directive were not needed for this localized CI repair. Additional guidance loaded included adaptive routing, agent permissions, workspace isolation, task framing, systematic debugging, self-audit, and the GitHub CI/publishing workflows.