### PR TITLE
fix: unblock Changesets release PR CI gates

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -51,7 +51,7 @@ jobs:
   pr-template:
     name: PR Template
     runs-on: ubuntu-latest
-    if: github.actor != 'dependabot[bot]'
+    if: github.actor != 'dependabot[bot]' && github.head_ref != 'changeset-release/main'
     steps:
       - name: Validate checklist
         env:
@@ -129,6 +129,7 @@ jobs:
   package-version:
     name: Package Version Guard
     runs-on: ubuntu-latest
+    if: github.head_ref != 'changeset-release/main'
     steps:
       - uses: actions/checkout@v7
         with:

--- a/packages/quality-cli/tests/package.test.ts
+++ b/packages/quality-cli/tests/package.test.ts
@@ -9,6 +9,9 @@ const README = fileURLToPath(new URL("../README.md", import.meta.url));
 const ROOT_README = fileURLToPath(
   new URL("../../../README.md", import.meta.url),
 );
+const PLUGIN_PACKAGE_JSON = fileURLToPath(
+  new URL("../../eslint-plugin/package.json", import.meta.url),
+);
 
 describe("quality CLI package metadata", () => {
   it("wires the llm-core-quality bin to the built CLI", async () => {
@@ -25,10 +28,16 @@ describe("quality CLI package metadata", () => {
     const pkg = JSON.parse(await readFile(PACKAGE_JSON, "utf8")) as {
       dependencies?: Record<string, string>;
     };
+    const pluginPkg = JSON.parse(
+      await readFile(PLUGIN_PACKAGE_JSON, "utf8"),
+    ) as { version: string };
 
+    // eslint-plugin-llm-core is pinned exactly and bumped by Changesets on
+    // every plugin release, so assert against its live version rather than
+    // a literal that goes stale each release.
     expect(pkg.dependencies).toMatchObject({
       eslint: "^10.8.1",
-      "eslint-plugin-llm-core": "0.35.1",
+      "eslint-plugin-llm-core": pluginPkg.version,
       knip: "^6.32.2",
       picocolors: expect.any(String),
     });


### PR DESCRIPTION
## What does this PR do?

Fixes CI failures on the Changesets "Version Packages" release PR (#337, branch `changeset-release/main`), which currently fails all three of its non-trivial checks:

- **Package Version Guard** — has no bot/release exemption; blocks the release PR's own expected version bump.
- **PR Template** — already exempts `dependabot[bot]` but not the Changesets release bot; the release PR body has no `## Checklist` section.
- **build** — `packages/quality-cli/tests/package.test.ts` hardcodes the exact pinned `eslint-plugin-llm-core` dependency version as a literal string. Since `.changeset/config.json` sets `updateInternalDependencies: "patch"`, Changesets bumps that pin on every plugin release, so this test was guaranteed to fail on every future release PR.

Changes:
- `.github/workflows/pr-checks.yml`: exempt `github.head_ref == 'changeset-release/main'` from the `pr-template` and `package-version` jobs (mirrors the existing `dependabot[bot]` exemption pattern).
- `packages/quality-cli/tests/package.test.ts`: assert the `eslint-plugin-llm-core` dependency pin against the plugin's live `package.json` version instead of a hardcoded literal.

## Verification

No `src/` changes; docs/CI-only. Verified locally:
- `npm --workspace llm-core-quality test` passes.
- Simulated a Changesets-style version bump (bumped both `packages/eslint-plugin/package.json` version and the `eslint-plugin-llm-core` dependency pin in `packages/quality-cli/package.json` to `0.36.0`) and confirmed the updated test still passes, then reverted.
- `npm run test` (full suite) passes.
- `npm run format:check` passes.
- Parsed the edited workflow YAML with `js-yaml` to confirm it's still valid.
- Pre-existing, unrelated lint error (`No tsconfigRootDir was set...`) reproduces identically on `main` without this change — caused by a local worktree directory, not present in CI.

## Checklist

- [x] `npm run build` passes
- [x] `npm run test` passes (new tests added if applicable) — no new tests; existing test corrected to stop hardcoding a value Changesets manages
- [x] `npm run lint` passes — N/A, pre-existing environmental failure unrelated to this diff (reproduces on main)
- [ ] `npm run update:eslint-docs` ran (if rules were added or changed) — N/A, no rule changes
- [ ] Docs added/updated (if adding a new rule) — N/A
- [ ] Rule exported in `src/rules/index.ts` (if adding a new rule) — N/A
- [ ] Rule added to `recommendedRules` in `src/index.ts` (if applicable) — N/A

## Agent Disclosure (complete if this PR was authored by an AI agent)

**Agent:** Claude Code

**Instruction files loaded:**

- [ ] `.github/copilot-instructions.md`
- [ ] `.github/instructions/rule-implementation.md`
- [ ] `.github/instructions/rule-tests.md`
- [ ] `.github/instructions/rule-docs.md`
- [ ] `.github/instructions/plugin-config.md`
- [x] `AGENTS.md` (via project `CLAUDE.md`)
- [ ] `.agents/directives/TYPE_DRIVEN_DEVELOPMENT.md`
- [ ] `.agents/directives/TEST_DRIVEN_DEVELOPMENT.md`
- [ ] `.agents/directives/CODEBASE_NAVIGATION.md`
- [ ] `.agents/directives/ERROR_MEMORY.md`
- [ ] `.agents/directives/VERIFICATION.md`
- [ ] `.agents/directives/SESSION_DECISIONS.md`
- [ ] N/A — no durable cross-cutting decision beyond the CI exemption itself, which is captured in this diff/PR description

**Instruction files NOT loaded (explain if unexpected):**

This was a targeted CI/infra bugfix (diagnosing and fixing a failing release PR), not a rule-implementation task, so `rule-implementation.md`/`rule-tests.md`/`rule-docs.md`/`plugin-config.md` do not apply (no `src/rules/**` or test-under-`tests/rules/**` files touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)